### PR TITLE
[Feature] 관리자 관련 기능 추가 #SCRUM-30

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ out/
 */.DS_Store
 application-dev.yml
 application-prod.yml
+**/src/main/resources/firebase/

--- a/build.gradle
+++ b/build.gradle
@@ -50,6 +50,9 @@ dependencies {
     // lombok test
     testCompileOnly 'org.projectlombok:lombok'
     testAnnotationProcessor 'org.projectlombok:lombok'
+
+    // firebase
+    implementation 'com.google.firebase:firebase-admin:9.3.0'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/groomiz/billage/auth/service/AuthService.java
+++ b/src/main/java/com/groomiz/billage/auth/service/AuthService.java
@@ -73,6 +73,9 @@ public class AuthService {
 
 		// 응답에서 RefreshToken 헤더를 제거
 		response.setHeader("RefreshToken", "");
+
+		// Redis에서 FCM Token 삭제
+		redisService.deleteValues("FCM_" + username);
 	}
 
 	private Authentication authenticate(LoginRequest loginRequest) throws AuthenticationException {

--- a/src/main/java/com/groomiz/billage/building/entity/Building.java
+++ b/src/main/java/com/groomiz/billage/building/entity/Building.java
@@ -1,5 +1,8 @@
 package com.groomiz.billage.building.entity;
 
+import java.util.List;
+
+import com.groomiz.billage.classroom.entity.Classroom;
 import com.groomiz.billage.common.entity.BaseEntity;
 
 import jakarta.persistence.Column;
@@ -7,6 +10,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -29,6 +33,9 @@ public class Building extends BaseEntity {
 
 	@Column(name = "image_url")
 	private String imageUrl;
+
+	@OneToMany(mappedBy = "building")
+	private List<Classroom> classrooms;
 
 	@Builder
 	public Building(String name, String number, String imageUrl) {

--- a/src/main/java/com/groomiz/billage/building/entity/BuildingAdmin.java
+++ b/src/main/java/com/groomiz/billage/building/entity/BuildingAdmin.java
@@ -30,4 +30,9 @@ public class BuildingAdmin extends BaseEntity {
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "building_id", nullable = false)
 	private Building building;
+
+	public BuildingAdmin(Member admin, Building building) {
+		this.admin = admin;
+		this.building = building;
+	}
 }

--- a/src/main/java/com/groomiz/billage/building/repository/BuildingAdminRepository.java
+++ b/src/main/java/com/groomiz/billage/building/repository/BuildingAdminRepository.java
@@ -1,0 +1,15 @@
+package com.groomiz.billage.building.repository;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import com.groomiz.billage.building.entity.BuildingAdmin;
+import com.groomiz.billage.member.entity.Member;
+
+public interface BuildingAdminRepository extends JpaRepository<BuildingAdmin, Long> {
+
+	@Query("SELECT ba.building.id FROM BuildingAdmin ba WHERE ba.admin = :admin")
+	List<Long> findAllBuildingIdByAdmin(Member admin);
+}

--- a/src/main/java/com/groomiz/billage/building/repository/BuildingRepository.java
+++ b/src/main/java/com/groomiz/billage/building/repository/BuildingRepository.java
@@ -1,9 +1,17 @@
 package com.groomiz.billage.building.repository;
 
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import com.groomiz.billage.building.entity.Building;
 
 public interface BuildingRepository extends JpaRepository<Building, Long> {
 
+	@Query("SELECT DISTINCT b FROM Building b "
+		+ "JOIN FETCH b.classrooms c "
+		+ "WHERE (:buildingIds IS NULL OR b.id IN :buildingIds) "
+		+ "AND (:floors IS NULL OR c.floor IN :floors)")
+	List<Building> findBuildingsWithClassroomByIdsAndFloors(List<Long> buildingIds, List<Long> floors);
 }

--- a/src/main/java/com/groomiz/billage/classroom/controller/AdminClassroomController.java
+++ b/src/main/java/com/groomiz/billage/classroom/controller/AdminClassroomController.java
@@ -1,7 +1,6 @@
 package com.groomiz.billage.classroom.controller;
 
 import java.time.LocalDate;
-import java.util.List;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -36,11 +35,11 @@ public class AdminClassroomController {
 	@PostMapping
 	@Operation(summary = "강의실 현황 필터링")
 	@ApiErrorExceptionsExample(AdminClassroomFilterExceptionDocs.class)
-	public ResponseEntity<List<AdminClassroomStatusResponse>> getClassrooms(
+	public ResponseEntity<AdminClassroomStatusResponse> getClassrooms(
 		@RequestBody AdminClassroomStatusRequest request) {
 
-		ResponseEntity<List<AdminClassroomStatusResponse>> response = null;
-		return response;
+		AdminClassroomStatusResponse response = adminClassroomService.findClassroomsByFilter(request);
+		return ResponseEntity.ok(response);
 	}
 
 	@GetMapping("/info/{id}")

--- a/src/main/java/com/groomiz/billage/classroom/controller/AdminClassroomController.java
+++ b/src/main/java/com/groomiz/billage/classroom/controller/AdminClassroomController.java
@@ -1,9 +1,11 @@
 package com.groomiz.billage.classroom.controller;
 
+import java.time.LocalDate;
 import java.util.List;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -13,8 +15,9 @@ import org.springframework.web.bind.annotation.RestController;
 import com.groomiz.billage.classroom.document.AdminClassroomFilterExceptionDocs;
 import com.groomiz.billage.classroom.document.AdminClassroomSearchExceptionDocs;
 import com.groomiz.billage.classroom.dto.request.AdminClassroomStatusRequest;
+import com.groomiz.billage.classroom.dto.response.AdminClassroomDetailResponse;
 import com.groomiz.billage.classroom.dto.response.AdminClassroomStatusResponse;
-import com.groomiz.billage.classroom.dto.response.ClassroomDetailResponse;
+import com.groomiz.billage.classroom.service.AdminClassroomService;
 import com.groomiz.billage.global.anotation.ApiErrorExceptionsExample;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -27,6 +30,9 @@ import lombok.RequiredArgsConstructor;
 @RequestMapping("/api/v1/admin/classrooms")
 @Tag(name = "Admin Classroom Controller", description = "[관리자] 강의실 관련 API")
 public class AdminClassroomController {
+
+	private final AdminClassroomService adminClassroomService;
+
 	@PostMapping
 	@Operation(summary = "강의실 현황 필터링")
 	@ApiErrorExceptionsExample(AdminClassroomFilterExceptionDocs.class)
@@ -37,15 +43,17 @@ public class AdminClassroomController {
 		return response;
 	}
 
-	@GetMapping("/info")
+	@GetMapping("/info/{id}")
 	@Operation(summary = "강의실 상세 조회")
 	@ApiErrorExceptionsExample(AdminClassroomSearchExceptionDocs.class)
-	public ResponseEntity<ClassroomDetailResponse> findByClassroomId(
+	public ResponseEntity<AdminClassroomDetailResponse> findByClassroomIdAndDate(
 		@Parameter(description = "강의실 ID", example = "1")
-		@RequestParam("id") Long id) {
+		@PathVariable("id") Long id,
+		@Parameter(description = "날짜", example = "2024-11-03")
+		@RequestParam("date") LocalDate date) {
 
-		ResponseEntity<ClassroomDetailResponse> response = null;
-		return response;
+		AdminClassroomDetailResponse classroom = adminClassroomService.findClassroomByIdAndDate(id, date);
+		return ResponseEntity.ok(classroom);
 	}
 
 }

--- a/src/main/java/com/groomiz/billage/classroom/controller/ClassroomController.java
+++ b/src/main/java/com/groomiz/billage/classroom/controller/ClassroomController.java
@@ -1,9 +1,11 @@
 package com.groomiz.billage.classroom.controller;
 
+import java.time.LocalDate;
 import java.util.List;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -13,6 +15,7 @@ import org.springframework.web.bind.annotation.RestController;
 import com.groomiz.billage.classroom.dto.request.ClassroomListRequest;
 import com.groomiz.billage.classroom.dto.response.ClassroomDetailResponse;
 import com.groomiz.billage.classroom.dto.response.ClassroomListResponse;
+import com.groomiz.billage.classroom.service.ClassroomService;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -25,6 +28,8 @@ import lombok.RequiredArgsConstructor;
 @Tag(name = "Classroom Controller", description = "[학생] 강의실 관련 API")
 public class ClassroomController {
 
+	private final ClassroomService classroomService;
+
 	@PostMapping
 	@Operation(summary = "강의실 목록 조회")
 	public ResponseEntity<List<ClassroomListResponse>> findAll(@RequestBody ClassroomListRequest request) {
@@ -33,13 +38,15 @@ public class ClassroomController {
 		return ResponseEntity.ok(response);
 	}
 
-	@GetMapping("/info")
+	@GetMapping("/info/{id}")
 	@Operation(summary = "강의실 상세 조회")
-	public ResponseEntity<ClassroomDetailResponse> findByClassroomId(
+	public ResponseEntity<ClassroomDetailResponse> findByClassroomIdAndDate(
 		@Parameter(description = "강의실 ID", example = "1")
-		@RequestParam("id") Long id) {
+		@PathVariable("id") Long id,
+		@Parameter(description = "날짜", example = "2024-11-03")
+		@RequestParam("date") LocalDate date) {
 
-		ClassroomDetailResponse response = new ClassroomDetailResponse();
-		return ResponseEntity.ok(response);
+		ClassroomDetailResponse classroom = classroomService.findClassroomByIdAndDate(id, date);
+		return ResponseEntity.ok(classroom);
 	}
 }

--- a/src/main/java/com/groomiz/billage/classroom/dto/ReservationTime.java
+++ b/src/main/java/com/groomiz/billage/classroom/dto/ReservationTime.java
@@ -2,12 +2,16 @@ package com.groomiz.billage.classroom.dto;
 
 import java.time.LocalTime;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
+
 import lombok.Getter;
 
 @Getter
 public class ReservationTime {
 
+	@JsonFormat(pattern = "HH:mm")
 	private LocalTime startTime;
+	@JsonFormat(pattern = "HH:mm")
 	private LocalTime endTime;
 
 	public ReservationTime(LocalTime startTime, LocalTime endTime) {

--- a/src/main/java/com/groomiz/billage/classroom/dto/ReservationTime.java
+++ b/src/main/java/com/groomiz/billage/classroom/dto/ReservationTime.java
@@ -3,7 +3,9 @@ package com.groomiz.billage.classroom.dto;
 import java.time.LocalTime;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import com.groomiz.billage.reservation.entity.Reservation;
 
+import lombok.Builder;
 import lombok.Getter;
 
 @Getter
@@ -14,8 +16,16 @@ public class ReservationTime {
 	@JsonFormat(pattern = "HH:mm")
 	private LocalTime endTime;
 
+	@Builder
 	public ReservationTime(LocalTime startTime, LocalTime endTime) {
 		this.startTime = startTime;
 		this.endTime = endTime;
+	}
+
+	public static ReservationTime from(Reservation reservation) {
+		return ReservationTime.builder()
+			.startTime(reservation.getStartTime())
+			.endTime(reservation.getEndTime())
+			.build();
 	}
 }

--- a/src/main/java/com/groomiz/billage/classroom/dto/request/AdminClassroomStatusRequest.java
+++ b/src/main/java/com/groomiz/billage/classroom/dto/request/AdminClassroomStatusRequest.java
@@ -3,11 +3,8 @@ package com.groomiz.billage.classroom.dto.request;
 import java.time.LocalDate;
 import java.util.List;
 
-import com.fasterxml.jackson.annotation.JsonFormat;
-
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Pattern;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -21,7 +18,6 @@ import lombok.NoArgsConstructor;
 public class AdminClassroomStatusRequest {
 
 	@NotNull
-	@Pattern(regexp = "\\d{4}-\\d{2}-\\d{2}", message = "날짜 형식은 yyyy-MM-dd여야 합니다.")
 	@Schema(description = "날짜", example = "2024-09-04")
 	private LocalDate date;
 

--- a/src/main/java/com/groomiz/billage/classroom/dto/response/AdminClassroomDetailResponse.java
+++ b/src/main/java/com/groomiz/billage/classroom/dto/response/AdminClassroomDetailResponse.java
@@ -4,29 +4,30 @@ import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.List;
 
-import com.fasterxml.jackson.annotation.JsonFormat;
+import com.groomiz.billage.classroom.entity.Classroom;
+import com.groomiz.billage.member.entity.Member;
+import com.groomiz.billage.reservation.entity.Reservation;
+import com.groomiz.billage.reservation.entity.ReservationStatusType;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import lombok.AllArgsConstructor;
+import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
 @Data
-@Builder
-@NoArgsConstructor
-@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Schema(description = "강의실 상세 조회 응답 DTO")
 public class AdminClassroomDetailResponse {
 
 	@Schema(description = "조회 날짜", example = "2024-09-04")
-	private String date;
+	private LocalDate date;
 
 	@Schema(description = "건물 이름", example = "어의관")
 	private String buildingName;
 
 	@Schema(description = "층", example = "3")
-	private int floor;
+	private Long floor;
 
 	@Schema(description = "강의실 이름", example = "실험실")
 	private String classroomName;
@@ -35,14 +36,15 @@ public class AdminClassroomDetailResponse {
 	private List<ReservationDetail> reservations;
 
 	@Data
-	@Builder
-	@NoArgsConstructor
-	@AllArgsConstructor
+	@NoArgsConstructor(access = AccessLevel.PROTECTED)
 	@Schema(description = "예약 상세 정보")
 	public static class ReservationDetail {
 
 		@Schema(description = "예약 ID", example = "1")
 		private Long reservationId;
+
+		@Schema(description = "예약 상태", example = "APPROVED")
+		private ReservationStatusType status;
 
 		@Schema(description = "예약 날짜", example = "2024-09-04")
 		private LocalDate date;
@@ -60,6 +62,60 @@ public class AdminClassroomDetailResponse {
 		private String memberName;
 
 		@Schema(description = "예약자 학번", example = "20201234")
-		private String studentId;
+		private String studentNumber;
+
+		@Builder
+		public ReservationDetail(Long reservationId, ReservationStatusType status, LocalDate date, LocalTime startTime, LocalTime endTime,
+			Integer headcount,
+			String memberName, String studentNumber) {
+			this.reservationId = reservationId;
+			this.status = status;
+			this.date = date;
+			this.startTime = startTime;
+			this.endTime = endTime;
+			this.headcount = headcount;
+			this.memberName = memberName;
+			this.studentNumber = studentNumber;
+		}
+
+		public static ReservationDetail from(Reservation reservation) {
+			Member requester = reservation.getReservationStatus().getRequester();
+
+			return ReservationDetail.builder()
+				.reservationId(reservation.getId())
+				.status(reservation.getReservationStatus().getStatus())
+				.date(reservation.getApplyDate())
+				.startTime(reservation.getStartTime())
+				.endTime(reservation.getEndTime())
+				.headcount(reservation.getHeadcount())
+				.memberName(requester.getUsername())
+				.studentNumber(requester.getStudentNumber())
+				.build();
+		}
+	}
+
+	@Builder
+	public AdminClassroomDetailResponse(LocalDate date, String buildingName, Long floor, String classroomName,
+		List<ReservationDetail> reservations) {
+		this.date = date;
+		this.buildingName = buildingName;
+		this.floor = floor;
+		this.classroomName = classroomName;
+		this.reservations = reservations;
+	}
+
+	public static AdminClassroomDetailResponse from(Classroom classroom, LocalDate date) {
+		List<Reservation> reservations = classroom.getReservations();
+
+
+		return AdminClassroomDetailResponse.builder()
+			.date(date)
+			.buildingName(classroom.getBuilding().getName())
+			.floor(classroom.getFloor())
+			.classroomName(classroom.getName())
+			.reservations(reservations.stream()
+				.map(ReservationDetail::from)
+				.toList())
+			.build();
 	}
 }

--- a/src/main/java/com/groomiz/billage/classroom/dto/response/AdminClassroomStatusResponse.java
+++ b/src/main/java/com/groomiz/billage/classroom/dto/response/AdminClassroomStatusResponse.java
@@ -2,20 +2,22 @@ package com.groomiz.billage.classroom.dto.response;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
-import com.fasterxml.jackson.annotation.JsonFormat;
+import com.groomiz.billage.building.entity.Building;
 import com.groomiz.billage.classroom.dto.ReservationTime;
+import com.groomiz.billage.classroom.entity.Classroom;
+import com.groomiz.billage.reservation.entity.Reservation;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import lombok.AllArgsConstructor;
+import lombok.AccessLevel;
 import lombok.Builder;
-import lombok.Data;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-@Data
-@Builder
-@NoArgsConstructor
-@AllArgsConstructor
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Schema(description = "강의실 현황 필터링 응답 DTO")
 public class AdminClassroomStatusResponse {
 
@@ -24,39 +26,94 @@ public class AdminClassroomStatusResponse {
 
 	@Schema(description = "필터링 건물 리스트")
 	private List<BuildingResponse> buildings;
+
+	@Getter
+	@NoArgsConstructor(access = AccessLevel.PROTECTED)
+	@Schema(description = "필터링 건물 정보")
+	static class BuildingResponse {
+
+		@Schema(description = "건물 이름", example = "미래관")
+		private String buildingName;
+
+		@Schema(description = "필터링 강의실 리스트")
+		private List<ClassroomResponse> classrooms;
+
+		@Builder
+		public BuildingResponse(String buildingName, List<ClassroomResponse> classrooms) {
+			this.buildingName = buildingName;
+			this.classrooms = classrooms;
+		}
+
+		public static BuildingResponse from(Building building, Map<Long, List<Reservation>> reservationsByClassroom) {
+			List<ClassroomResponse> classrooms = building.getClassrooms().stream()
+				.map(classroom -> ClassroomResponse.from(classroom, reservationsByClassroom.getOrDefault(classroom.getId(), List.of())))
+				.collect(Collectors.toList());
+
+			return BuildingResponse.builder()
+				.buildingName(building.getName())
+				.classrooms(classrooms)
+				.build();
+		}
+
+		@Getter
+		@NoArgsConstructor(access = AccessLevel.PROTECTED)
+		@Schema(description = "필터링 강의실 정보")
+		static class ClassroomResponse {
+
+			@Schema(description = "층", example = "1")
+			private Long floor;
+
+			@Schema(description = "강의실 번호", example = "101")
+			private String classroomNumber;
+
+			@Schema(description = "시간 정보 리스트")
+			private List<ReservationTime> time;
+
+			@Schema(description = "인원 수")
+			private Integer headcount;
+
+			@Builder
+			public ClassroomResponse(Long floor, String classroomNumber, List<ReservationTime> time,
+				Integer headcount) {
+				this.floor = floor;
+				this.classroomNumber = classroomNumber;
+				this.time = time;
+				this.headcount = headcount;
+			}
+
+			public static ClassroomResponse from(Classroom classroom, List<Reservation> reservations) {
+				return ClassroomResponse.builder()
+					.floor(classroom.getFloor())
+					.classroomNumber(classroom.getNumber())
+					.time(reservations.stream()
+						.map(ReservationTime::from)
+						.collect(Collectors.toList()))
+					.headcount(classroom.getCapacity())
+					.build();
+			}
+		}
+
+	}
+
+	@Builder
+	public AdminClassroomStatusResponse(LocalDate date, List<BuildingResponse> buildings) {
+		this.date = date;
+		this.buildings = buildings;
+	}
+
+	public static AdminClassroomStatusResponse of(LocalDate date, List<Building> buildings, List<Reservation> reservations) {
+		// 강의실 단위로 예약 그룹화
+		Map<Long, List<Reservation>> reservationsByClassroom = reservations.stream()
+			.collect(Collectors.groupingBy(r -> r.getClassroom().getId()));
+
+		// 각 강의실에 해당하는 예약을 전달
+		List<BuildingResponse> buildingResponses = buildings.stream()
+			.map(building -> BuildingResponse.from(building, reservationsByClassroom))
+			.collect(Collectors.toList());
+
+		return AdminClassroomStatusResponse.builder()
+			.date(date)
+			.buildings(buildingResponses)
+			.build();
+	}
 }
-
-@Data
-@Builder
-@NoArgsConstructor
-@AllArgsConstructor
-@Schema(description = "필터링 건물 정보")
-class BuildingResponse {
-
-	@Schema(description = "건물 이름", example = "미래관")
-	private String buildingName;
-
-	@Schema(description = "필터링 강의실 리스트")
-	private List<ClassroomResponse> classrooms;
-}
-
-@Data
-@Builder
-@NoArgsConstructor
-@AllArgsConstructor
-@Schema(description = "필터링 강의실 정보")
-class ClassroomResponse {
-
-	@Schema(description = "층", example = "1")
-	private Long floor;
-
-	@Schema(description = "강의실 번호", example = "101")
-	private String classroomNumber;
-
-	@Schema(description = "시간 정보 리스트")
-	private List<ReservationTime> time;
-
-	@Schema(description = "인원 수")
-	private Integer headcount;
-}
-

--- a/src/main/java/com/groomiz/billage/classroom/dto/response/ClassroomDetailResponse.java
+++ b/src/main/java/com/groomiz/billage/classroom/dto/response/ClassroomDetailResponse.java
@@ -1,10 +1,15 @@
 package com.groomiz.billage.classroom.dto.response;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 import com.groomiz.billage.classroom.dto.ReservationTime;
+import com.groomiz.billage.classroom.entity.Classroom;
+import com.groomiz.billage.classroom.entity.ClassroomImage;
+import com.groomiz.billage.reservation.entity.Reservation;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
 import lombok.Data;
 
 @Data
@@ -22,7 +27,42 @@ public class ClassroomDetailResponse {
 	@Schema(description = "강의실 설명", example = "빔 프로젝터, 컴퓨터, 사물함")
 	private String description;
 	@Schema(description = "강의실 이미지", example = "https://groomiz.com/classroom/1.jpg")
-	private String classroomImage;
+	private List<String> classroomImages;
 	@Schema(description = "예약된 시간", example = "[{\"startTime\":\"09:00\",\"endTime\":\"10:00\"}]")
 	private List<ReservationTime> reservationTimes;
+
+	@Builder
+	public ClassroomDetailResponse(Long classroomId, String classroomName, String classroomNumber, Integer capacity,
+		String description, List<String> classroomImages, List<ReservationTime> reservationTimes) {
+		this.classroomId = classroomId;
+		this.classroomName = classroomName;
+		this.classroomNumber = classroomNumber;
+		this.capacity = capacity;
+		this.description = description;
+		this.classroomImages = classroomImages;
+		this.reservationTimes = reservationTimes;
+	}
+
+	public static ClassroomDetailResponse from(Classroom classroom) {
+		
+		List<ClassroomImage> images = classroom.getImages();
+		List<Reservation> reservations = classroom.getReservations();
+
+		return ClassroomDetailResponse.builder()
+			.classroomId(classroom.getId())
+			.classroomName(classroom.getName())
+			.classroomNumber(classroom.getNumber())
+			.capacity(classroom.getCapacity())
+			.description(classroom.getDescription())
+			.classroomImages(images.stream()
+				.map(ClassroomImage::getImageUrl)
+				.collect(Collectors.toList()))
+			.reservationTimes(
+				reservations.stream()
+					.map(reservation -> new ReservationTime(reservation.getStartTime(), reservation.getEndTime()))
+					.collect(Collectors.toList())
+			)
+			.build();
+	}
+	
 }

--- a/src/main/java/com/groomiz/billage/classroom/entity/Classroom.java
+++ b/src/main/java/com/groomiz/billage/classroom/entity/Classroom.java
@@ -1,7 +1,10 @@
 package com.groomiz.billage.classroom.entity;
 
+import java.util.List;
+
 import com.groomiz.billage.building.entity.Building;
 import com.groomiz.billage.common.entity.BaseEntity;
+import com.groomiz.billage.reservation.entity.Reservation;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -11,6 +14,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -39,6 +43,12 @@ public class Classroom extends BaseEntity {
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "building_id", nullable = false)
 	private Building building;
+
+	@OneToMany(mappedBy = "classroom")
+	private List<ClassroomImage> images;
+
+	@OneToMany(mappedBy = "classroom")
+	private List<Reservation> reservations;
 
 	@Builder
 	public Classroom(String name, String number, Long floor, String description, Integer capacity, Building building) {

--- a/src/main/java/com/groomiz/billage/classroom/repository/ClassroomRepository.java
+++ b/src/main/java/com/groomiz/billage/classroom/repository/ClassroomRepository.java
@@ -1,8 +1,20 @@
 package com.groomiz.billage.classroom.repository;
 
+import java.time.LocalDate;
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import com.groomiz.billage.classroom.entity.Classroom;
 
 public interface ClassroomRepository extends JpaRepository<Classroom, Long> {
+
+	@Query("SELECT c FROM Classroom c "
+		+ "JOIN FETCH c.reservations r "
+		+ "JOIN FETCH r.reservationStatus rs "
+		+ "WHERE c.id = :classroomId "
+		+ "AND r.applyDate = :date "
+		+ "AND rs.status in ('PENDING', 'APPROVED')")
+	Optional<Classroom> findClassroomByIdAndDate(Long classroomId, LocalDate date);
 }

--- a/src/main/java/com/groomiz/billage/classroom/service/AdminClassroomService.java
+++ b/src/main/java/com/groomiz/billage/classroom/service/AdminClassroomService.java
@@ -1,15 +1,23 @@
 package com.groomiz.billage.classroom.service;
 
 import java.time.LocalDate;
+import java.util.List;
+import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.groomiz.billage.building.entity.Building;
+import com.groomiz.billage.building.repository.BuildingRepository;
+import com.groomiz.billage.classroom.dto.request.AdminClassroomStatusRequest;
 import com.groomiz.billage.classroom.dto.response.AdminClassroomDetailResponse;
+import com.groomiz.billage.classroom.dto.response.AdminClassroomStatusResponse;
 import com.groomiz.billage.classroom.entity.Classroom;
 import com.groomiz.billage.classroom.exception.ClassroomErrorCode;
 import com.groomiz.billage.classroom.exception.ClassroomException;
 import com.groomiz.billage.classroom.repository.ClassroomRepository;
+import com.groomiz.billage.reservation.entity.Reservation;
+import com.groomiz.billage.reservation.repository.ReservationRepository;
 
 import lombok.RequiredArgsConstructor;
 
@@ -19,6 +27,8 @@ import lombok.RequiredArgsConstructor;
 public class AdminClassroomService {
 
 	private final ClassroomRepository classroomRepository;
+	private final BuildingRepository buildingRepository;
+	private final ReservationRepository reservationRepository;
 
 	@Transactional(readOnly = true)
 	public AdminClassroomDetailResponse findClassroomByIdAndDate(Long classroomId, LocalDate date) {
@@ -27,5 +37,30 @@ public class AdminClassroomService {
 			.orElseThrow(() -> new ClassroomException(ClassroomErrorCode.CLASSROOM_NOT_FOUND));
 
 		return AdminClassroomDetailResponse.from(classroom, date);
+	}
+
+	@Transactional(readOnly = true)
+	public AdminClassroomStatusResponse findClassroomsByFilter(AdminClassroomStatusRequest request) {
+
+		// 건물 조회
+		List<Long> buildingIds = (request.getBuildings() == null || request.getBuildings().isEmpty())
+			? null : request.getBuildings();
+		List<Long> floors = (request.getFloors() == null || request.getFloors().isEmpty())
+			? null : request.getFloors();
+
+		List<Building> buildings = buildingRepository.findBuildingsWithClassroomByIdsAndFloors(
+		buildingIds, floors);
+
+		// 건물에 속한 강의실 ID 추출
+		List<Long> classroomIds = buildings.stream()
+			.flatMap(building -> building.getClassrooms().stream())
+			.map(Classroom::getId)
+			.collect(Collectors.toList());
+
+		// 특정 날짜 강의실 예약 조회
+		List<Reservation> reservations = reservationRepository.findReservationsByClassroomIdsAndDate(
+			classroomIds, request.getDate());
+
+		return AdminClassroomStatusResponse.of(request.getDate(), buildings, reservations);
 	}
 }

--- a/src/main/java/com/groomiz/billage/classroom/service/AdminClassroomService.java
+++ b/src/main/java/com/groomiz/billage/classroom/service/AdminClassroomService.java
@@ -1,0 +1,31 @@
+package com.groomiz.billage.classroom.service;
+
+import java.time.LocalDate;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.groomiz.billage.classroom.dto.response.AdminClassroomDetailResponse;
+import com.groomiz.billage.classroom.entity.Classroom;
+import com.groomiz.billage.classroom.exception.ClassroomErrorCode;
+import com.groomiz.billage.classroom.exception.ClassroomException;
+import com.groomiz.billage.classroom.repository.ClassroomRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Transactional
+@Service
+public class AdminClassroomService {
+
+	private final ClassroomRepository classroomRepository;
+
+	@Transactional(readOnly = true)
+	public AdminClassroomDetailResponse findClassroomByIdAndDate(Long classroomId, LocalDate date) {
+
+		Classroom classroom = classroomRepository.findClassroomByIdAndDate(classroomId, date)
+			.orElseThrow(() -> new ClassroomException(ClassroomErrorCode.CLASSROOM_NOT_FOUND));
+
+		return AdminClassroomDetailResponse.from(classroom, date);
+	}
+}

--- a/src/main/java/com/groomiz/billage/classroom/service/ClassroomService.java
+++ b/src/main/java/com/groomiz/billage/classroom/service/ClassroomService.java
@@ -1,0 +1,31 @@
+package com.groomiz.billage.classroom.service;
+
+import java.time.LocalDate;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.groomiz.billage.classroom.dto.response.ClassroomDetailResponse;
+import com.groomiz.billage.classroom.entity.Classroom;
+import com.groomiz.billage.classroom.exception.ClassroomErrorCode;
+import com.groomiz.billage.classroom.exception.ClassroomException;
+import com.groomiz.billage.classroom.repository.ClassroomRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Transactional
+@Service
+public class ClassroomService {
+
+	private final ClassroomRepository classroomRepository;
+
+	@Transactional(readOnly = true)
+	public ClassroomDetailResponse findClassroomByIdAndDate(Long classroomId, LocalDate date) {
+
+		Classroom classroom = classroomRepository.findClassroomByIdAndDate(classroomId, date)
+			.orElseThrow(() -> new ClassroomException(ClassroomErrorCode.CLASSROOM_NOT_FOUND));
+
+		return ClassroomDetailResponse.from(classroom);
+	}
+}

--- a/src/main/java/com/groomiz/billage/common/util/DateUtills.java
+++ b/src/main/java/com/groomiz/billage/common/util/DateUtills.java
@@ -1,0 +1,11 @@
+package com.groomiz.billage.common.util;
+
+import java.time.LocalTime;
+
+public class DateUtills {
+
+	public static boolean isTimeOverlapping(LocalTime startTime1, LocalTime endTime1, LocalTime startTime2,
+		LocalTime endTime2) {
+		return startTime1.isBefore(endTime2) && startTime2.isBefore(endTime1);
+	}
+}

--- a/src/main/java/com/groomiz/billage/fcm/service/FCMService.java
+++ b/src/main/java/com/groomiz/billage/fcm/service/FCMService.java
@@ -1,0 +1,45 @@
+package com.groomiz.billage.fcm.service;
+
+import java.util.Objects;
+
+import org.springframework.stereotype.Service;
+
+import com.google.firebase.messaging.FirebaseMessaging;
+import com.google.firebase.messaging.FirebaseMessagingException;
+import com.google.firebase.messaging.Message;
+import com.google.firebase.messaging.Notification;
+import com.groomiz.billage.auth.document.LoginExceptionDocs;
+import com.groomiz.billage.auth.service.RedisService;
+import com.groomiz.billage.member.exception.MemberErrorCode;
+import com.groomiz.billage.member.exception.MemberException;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@RequiredArgsConstructor
+@Service
+@Slf4j
+public class FCMService {
+
+	private final RedisService redisService;
+	private final LoginExceptionDocs loginExceptionDocs;
+
+	public void sendMessage(String studentNumber, String title, String body) throws FirebaseMessagingException {
+		String key = "FCM_" + studentNumber;
+		String token = redisService.getValues(key);
+
+		if (Objects.equals(token, "false")) {
+			throw new MemberException(MemberErrorCode.FCM_TOKEN_NOT_FOUND);
+		}
+
+		Message message = Message.builder()
+			.setNotification(Notification.builder()
+				.setTitle(title)
+				.setBody(body)
+				.build())
+			.setToken(token)
+			.build();
+
+		FirebaseMessaging.getInstance().send(message);
+	}
+}

--- a/src/main/java/com/groomiz/billage/global/config/FirebaseConfig.java
+++ b/src/main/java/com/groomiz/billage/global/config/FirebaseConfig.java
@@ -1,0 +1,55 @@
+package com.groomiz.billage.global.config;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.io.ClassPathResource;
+
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.firebase.FirebaseApp;
+import com.google.firebase.FirebaseOptions;
+import com.google.firebase.messaging.FirebaseMessaging;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Configuration
+@Slf4j
+public class FirebaseConfig {
+
+	@Value("${fcm.key.path}")
+	private String SERViCE_ACCOUNT_JSON;
+
+	@Bean
+	FirebaseMessaging firebaseMessaging() throws IOException {
+		ClassPathResource resource = new ClassPathResource(SERViCE_ACCOUNT_JSON);
+
+		InputStream refreshToken = resource.getInputStream();
+
+		log.info("refreshToken : {}", refreshToken);
+
+		FirebaseApp firebaseApp = null;
+		List<FirebaseApp> firebaseAppList = FirebaseApp.getApps();
+
+		if (firebaseAppList != null && !firebaseAppList.isEmpty()) {
+			for (FirebaseApp app : firebaseAppList){
+				if (app.getName().equals(FirebaseApp.DEFAULT_APP_NAME)) {
+					firebaseApp = app;
+				}
+			}
+
+		} else {
+			FirebaseOptions options = FirebaseOptions.builder()
+				.setCredentials(GoogleCredentials.fromStream(refreshToken))
+				.build();
+			firebaseApp = FirebaseApp.initializeApp(options);
+
+		}
+
+		return FirebaseMessaging.getInstance(firebaseApp);
+	}
+
+}

--- a/src/main/java/com/groomiz/billage/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/groomiz/billage/global/exception/GlobalExceptionHandler.java
@@ -22,18 +22,24 @@ import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExcep
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.exc.InvalidFormatException;
+import com.fasterxml.jackson.databind.exc.ValueInstantiationException;
 import com.groomiz.billage.auth.document.LoginExceptionDocs;
 import com.groomiz.billage.global.dto.ErrorReason;
 import com.groomiz.billage.global.dto.ErrorResponse;
+import com.groomiz.billage.member.entity.College;
+import com.groomiz.billage.member.entity.Major;
 import com.groomiz.billage.member.exception.MemberErrorCode;
 import com.groomiz.billage.member.exception.MemberException;
+import com.groomiz.billage.reservation.entity.ReservationPurpose;
+import com.groomiz.billage.reservation.entity.ReservationStatusType;
+import com.groomiz.billage.reservation.entity.ReservationType;
+import com.groomiz.billage.reservation.exception.AdminReservationErrorCode;
+import com.groomiz.billage.reservation.exception.AdminReservationException;
 import com.groomiz.billage.reservation.exception.ReservationErrorCode;
 import com.groomiz.billage.reservation.exception.ReservationException;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.ConstraintViolationException;
-import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 
 @RestControllerAdvice
@@ -62,15 +68,51 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 		HttpServletRequest httpServletRequest = servletWebRequest.getRequest();
 		String url = httpServletRequest.getRequestURL().toString();
 
+		// 존재하지 않는 enum 값 예외 처리
+		if (ex.getCause() instanceof ValueInstantiationException) {
+			Class<?> rawClass = ((ValueInstantiationException)ex.getCause()).getType().getRawClass();
+
+			BaseErrorCode errorCode = null;
+			GlobalCodeException exception = null;
+
+			if (rawClass.equals(ReservationPurpose.class)) {
+				errorCode = ReservationErrorCode.INVALID_RESERVATION_PURPOSE;
+				exception = new ReservationException((ReservationErrorCode)errorCode);
+			} else if (rawClass.equals(ReservationStatusType.class)) {
+				errorCode = ReservationErrorCode.INVALID_RESERVATION_STATUS_TYPE;
+				exception = new ReservationException((ReservationErrorCode)errorCode);
+			} else if (rawClass.equals(ReservationType.class)) {
+				errorCode = AdminReservationErrorCode.INVALID_RESERVATION_TYPE;
+				exception = new AdminReservationException((AdminReservationErrorCode)errorCode);
+			} else if (rawClass.equals(College.class)) {
+				errorCode = MemberErrorCode.INVALID_COLLEGE_ENUM;
+				exception = new MemberException((MemberErrorCode)errorCode);
+			} else if (rawClass.equals(Major.class)) {
+				errorCode = MemberErrorCode.INVALID_MAJOR_ENUM;
+				exception = new MemberException((MemberErrorCode)errorCode);
+			} else {
+				errorCode = GlobalErrorCode.INTERNAL_SERVER_ERROR;
+				exception = new GlobalCodeException(errorCode);
+			}
+
+			ErrorReason reason = exception.getErrorReason();
+			ErrorResponse errorResponse =
+				new ErrorResponse(reason, url);
+
+			return ResponseEntity.status(HttpStatus.valueOf(reason.getStatus()))
+				.body(errorResponse);
+		}
+
+		// 날짜, 시간 예외 처리
 		if (ex.getCause().getCause() instanceof DateTimeParseException) {
 			String message = ex.getCause().getMessage();
 
 			ReservationErrorCode errorCode = null;
 
-			if (message.contains("LocalDate:")) { // LocalDate 형식 에러
+			if (message.contains("LocalDate:")) {
 				errorCode = ReservationErrorCode.INVALID_RESERVATION_DATE;
 			}
-			else if (message.contains("LocalTime:")) { // LocalTime 형식 에러
+			else if (message.contains("LocalTime:")) {
 				errorCode = ReservationErrorCode.INVALID_RESERVATION_TIME;
 			}
 			else {
@@ -104,6 +146,18 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 	@ExceptionHandler(ReservationException.class)
 	public ResponseEntity<ErrorResponse> handleReservationException(ReservationException ex, HttpServletRequest request) {
 
+		ErrorReason reason = ex.getErrorReason();
+		ErrorResponse errorResponse =
+			new ErrorResponse(ex.getErrorReason(), request.getRequestURL().toString());
+
+		return ResponseEntity.status(HttpStatus.valueOf(reason.getStatus()))
+			.body(errorResponse);
+	}
+
+	@ExceptionHandler(AdminReservationException.class)
+	public ResponseEntity<ErrorResponse> handleAdminReservationException(ReservationException ex, HttpServletRequest request) {
+
+		log.info("AdminReservationException: {}", ex.getMessage());
 		ErrorReason reason = ex.getErrorReason();
 		ErrorResponse errorResponse =
 			new ErrorResponse(ex.getErrorReason(), request.getRequestURL().toString());

--- a/src/main/java/com/groomiz/billage/member/controller/MemberController.java
+++ b/src/main/java/com/groomiz/billage/member/controller/MemberController.java
@@ -20,9 +20,9 @@ import com.groomiz.billage.global.anotation.ApiErrorExceptionsExample;
 import com.groomiz.billage.member.document.UserInfoEditExceptionDocs;
 import com.groomiz.billage.member.document.UserInfoExceptionDocs;
 import com.groomiz.billage.member.document.UserPasswordExceptionDocs;
-import com.groomiz.billage.member.dto.request.MemberInfoRequest;
-import com.groomiz.billage.member.dto.request.PasswordRequest;
-import com.groomiz.billage.member.dto.response.MemberInfoResponse;
+import com.groomiz.billage.member.dto.MemberInfoRequest;
+import com.groomiz.billage.member.dto.MemberInfoResponse;
+import com.groomiz.billage.member.dto.PasswordRequest;
 import com.groomiz.billage.member.service.MemberService;
 
 import io.swagger.v3.oas.annotations.Operation;

--- a/src/main/java/com/groomiz/billage/member/controller/MemberController.java
+++ b/src/main/java/com/groomiz/billage/member/controller/MemberController.java
@@ -1,23 +1,32 @@
 package com.groomiz.billage.member.controller;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.groomiz.billage.auth.dto.CustomUserDetails;
+import com.groomiz.billage.auth.service.RedisService;
 import com.groomiz.billage.common.dto.StringResponseDto;
 import com.groomiz.billage.global.anotation.ApiErrorExceptionsExample;
 import com.groomiz.billage.member.document.UserInfoEditExceptionDocs;
 import com.groomiz.billage.member.document.UserInfoExceptionDocs;
 import com.groomiz.billage.member.document.UserPasswordExceptionDocs;
-import com.groomiz.billage.member.dto.MemberInfoRequest;
-import com.groomiz.billage.member.dto.MemberInfoResponse;
-import com.groomiz.billage.member.dto.PasswordRequest;
+import com.groomiz.billage.member.dto.request.MemberInfoRequest;
+import com.groomiz.billage.member.dto.request.PasswordRequest;
+import com.groomiz.billage.member.dto.response.MemberInfoResponse;
+import com.groomiz.billage.member.service.MemberService;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 
@@ -26,6 +35,10 @@ import lombok.RequiredArgsConstructor;
 @RequestMapping("/api/v1/users")
 @Tag(name = "Member Controller", description = "회원 정보 관리 API")
 public class MemberController {
+
+	private static final Logger log = LoggerFactory.getLogger(MemberController.class);
+	private final MemberService memberService;
+	private final RedisService redisService;
 
 	@GetMapping("/info")
 	@Operation(summary = "회원 정보 조회")
@@ -47,7 +60,11 @@ public class MemberController {
 	@DeleteMapping
 	@Operation(summary = "회원 탈퇴")
 	@ApiErrorExceptionsExample(UserInfoExceptionDocs.class)
-	public ResponseEntity<StringResponseDto> delete() {
+	public ResponseEntity<StringResponseDto> delete(
+		@AuthenticationPrincipal CustomUserDetails user) {
+
+		// FCM 토큰 삭제
+		redisService.deleteValues("FCM_" + user);
 		return ResponseEntity.ok(new StringResponseDto("success"));
 	}
 
@@ -56,6 +73,17 @@ public class MemberController {
 	@ApiErrorExceptionsExample(UserPasswordExceptionDocs.class)
 	public ResponseEntity<StringResponseDto> updatePassword(@RequestBody PasswordRequest passwordRequest) {
 		return ResponseEntity.ok(new StringResponseDto("success"));
+	}
+
+	@PostMapping("/fcmtoken")
+	@Operation(summary = "FCM 토큰 저장")
+	public ResponseEntity<StringResponseDto> saveFcmToken(
+		@Schema(description = "FCM 토큰", example = "dlG5jjy4SvicNcWvENgF91:APA91bHSERS39latr_mu0jh1A")
+		@RequestHeader("FCM-Token") String token,
+		@AuthenticationPrincipal CustomUserDetails user) {
+
+		memberService.saveFCMToken(token, user.getStudentNumber());
+		return ResponseEntity.ok(new StringResponseDto("FCM 토큰 저장에 성공하였습니다."));
 	}
 
 }

--- a/src/main/java/com/groomiz/billage/member/exception/MemberErrorCode.java
+++ b/src/main/java/com/groomiz/billage/member/exception/MemberErrorCode.java
@@ -53,7 +53,10 @@ public enum MemberErrorCode implements BaseErrorCode {
 	INVALID_EMAIL(BAD_REQUEST, "MEMBER_400_11", "이메일 형식이 요구 조건에 맞지 않습니다."),
 
 	@ExplainError("회원이 존재하지 않는 경우 발생하는 오류입니다.")
-	MEMBER_NOT_FOUND(NOT_FOUND, "MEMBER_404_1", "해당 회원이 존재하지 않습니다.");
+	MEMBER_NOT_FOUND(NOT_FOUND, "MEMBER_404_1", "해당 회원이 존재하지 않습니다."),
+
+	@ExplainError("FCM 토큰이 존재하지 않는 경우 발생하는 오류입니다.")
+	FCM_TOKEN_NOT_FOUND(NOT_FOUND, "MEMBER_404_2", "FCM 토큰이 존재하지 않습니다."),;
 
 	private final Integer status;
 	private final String code;

--- a/src/main/java/com/groomiz/billage/member/service/MemberService.java
+++ b/src/main/java/com/groomiz/billage/member/service/MemberService.java
@@ -1,22 +1,29 @@
 package com.groomiz.billage.member.service;
 
+import java.time.Duration;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
-
+import org.springframework.transaction.annotation.Transactional;
 import com.groomiz.billage.auth.dto.RegisterRequest;
+import com.groomiz.billage.auth.service.RedisService;
 import com.groomiz.billage.member.entity.College;
 import com.groomiz.billage.member.entity.Major;
 import com.groomiz.billage.member.entity.Member;
 import com.groomiz.billage.member.entity.Role;
 import com.groomiz.billage.member.repository.MemberRepository;
-
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
 @Service
+@Transactional
 public class MemberService {
 	private final MemberRepository memberRepository;
 	private final BCryptPasswordEncoder passwordEncoder;
+	private final RedisService redisService;
+
+	@Value("${spring.data.redis.cache.fcm-ttl}")
+	private Long ttl;
 
 	//Todo : 약관동의도 넣어야 함
 	public void register(RegisterRequest registerRequest) {
@@ -34,6 +41,11 @@ public class MemberService {
 			.build();
 		memberRepository.save(member);
 
+	}
+
+	public void saveFCMToken(String token, String studentNumber) {
+		String key = "FCM_" + studentNumber;
+		redisService.setValues(key, token, Duration.ofMillis(ttl));
 	}
 
 	public boolean isExists(String studentNumber) {

--- a/src/main/java/com/groomiz/billage/reservation/controller/AdminReservationController.java
+++ b/src/main/java/com/groomiz/billage/reservation/controller/AdminReservationController.java
@@ -26,12 +26,14 @@ import com.groomiz.billage.reservation.dto.request.AdminReservationRequest;
 import com.groomiz.billage.reservation.dto.response.AdminReservationResponse;
 import com.groomiz.billage.reservation.dto.response.AdminReservationStatusListResponse;
 import com.groomiz.billage.reservation.service.AdminReservationService;
-import com.groomiz.billage.reservation.service.ReservationService;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @RestController
 @RequestMapping("/api/v1/admin/reservations")
 @Tag(name = "Admin Reservation Controller", description = "[관리자] 예약 관련 API")
@@ -97,7 +99,18 @@ public class AdminReservationController {
 	}
 
 	@DeleteMapping("/{id}")
-	@Operation(summary = "예약 삭제", description = "단일 예약, 기간 예약, 반복 예약을 삭제합니다.")
+	@Operation(summary = "예약 취소", description = "관리자 일반/기간/반복 예약을 취소합니다.")
+	@ApiErrorExceptionsExample(AdminReservationDeleteExceptionDocs.class)
+	public ResponseEntity<StringResponseDto> cancelReservation(
+		@Parameter(description = "예약 ID", example = "1")
+		@PathVariable("id") Long id,
+		@Parameter(description = "일괄 삭제 여부", example = "0")
+		@RequestParam(required = false, defaultValue = "0") boolean isDeleteAll,
+		@AuthenticationPrincipal CustomUserDetails user) {
+
+		adminReservationService.cancelReservation(id, isDeleteAll, user.getStudentNumber());
+		return ResponseEntity.ok(new StringResponseDto("예약 취소 완료되었습니다."));
+	}
 
 	@DeleteMapping("/{id}/student")
 	@Operation(summary = "예약 강제 취소", description = "학생 예약을 강제 취소합니다.")

--- a/src/main/java/com/groomiz/billage/reservation/controller/AdminReservationController.java
+++ b/src/main/java/com/groomiz/billage/reservation/controller/AdminReservationController.java
@@ -23,8 +23,10 @@ import com.groomiz.billage.reservation.document.AdminSearchExceptionDocs;
 import com.groomiz.billage.reservation.document.AdminbyStatusExceptionDocs;
 import com.groomiz.billage.reservation.dto.request.AdminRejectionRequest;
 import com.groomiz.billage.reservation.dto.request.AdminReservationRequest;
+import com.groomiz.billage.reservation.dto.response.AdminReservationResponse;
 import com.groomiz.billage.reservation.dto.response.AdminReservationStatusListResponse;
 import com.groomiz.billage.reservation.service.AdminReservationService;
+import com.groomiz.billage.reservation.service.ReservationService;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -73,7 +75,7 @@ public class AdminReservationController {
 	}
 
 	@PostMapping
-	@Operation(summary = "예약 요청 처리")
+	@Operation(summary = "강의실 예약(일반/기간/반복)")
 	@ApiErrorExceptionsExample(AdminReservationExceptionDocs.class)
 	public ResponseEntity<StringResponseDto> createReservation(
 		@RequestBody AdminReservationRequest request,
@@ -86,8 +88,12 @@ public class AdminReservationController {
 	@GetMapping("/{reservationId}")
 	@Operation(summary = "예약 상세 조회")
 	@ApiErrorExceptionsExample(AdminSearchExceptionDocs.class)
-	public ResponseEntity<StringResponseDto> getReservation(@PathVariable Long reservationId) {
-		return ResponseEntity.ok(null);
+	public ResponseEntity<AdminReservationResponse> getReservation(
+		@Parameter(description = "예약 ID", example = "1")
+		@PathVariable Long reservationId) {
+
+		AdminReservationResponse reservation = adminReservationService.getReservation(reservationId);
+		return ResponseEntity.ok(reservation);
 	}
 
 	@DeleteMapping("/{id}")

--- a/src/main/java/com/groomiz/billage/reservation/controller/AdminReservationController.java
+++ b/src/main/java/com/groomiz/billage/reservation/controller/AdminReservationController.java
@@ -99,9 +99,15 @@ public class AdminReservationController {
 	@DeleteMapping("/{id}")
 	@Operation(summary = "예약 삭제", description = "단일 예약, 기간 예약, 반복 예약을 삭제합니다.")
 
+	@DeleteMapping("/{id}/student")
+	@Operation(summary = "예약 강제 취소", description = "학생 예약을 강제 취소합니다.")
 	@ApiErrorExceptionsExample(AdminReservationDeleteExceptionDocs.class)
-	public ResponseEntity<StringResponseDto> deleteReservation(@PathVariable Long id,
-		@RequestParam(required = false, defaultValue = "single") String type) {
-		return ResponseEntity.ok(null);
+	public ResponseEntity<StringResponseDto> cancleStudentReservation(
+		@Parameter(description = "예약 ID", example = "1")
+		@PathVariable("id") Long id,
+		@AuthenticationPrincipal CustomUserDetails user) {
+
+		adminReservationService.cancelStudentReservation(id, user.getStudentNumber());
+		return ResponseEntity.ok(new StringResponseDto("학생 예약 강제 취소 완료되었습니다."));
 	}
 }

--- a/src/main/java/com/groomiz/billage/reservation/controller/AdminReservationController.java
+++ b/src/main/java/com/groomiz/billage/reservation/controller/AdminReservationController.java
@@ -76,7 +76,10 @@ public class AdminReservationController {
 	@Operation(summary = "예약 요청 처리")
 	@ApiErrorExceptionsExample(AdminReservationExceptionDocs.class)
 	public ResponseEntity<StringResponseDto> createReservation(
-		@RequestBody AdminReservationRequest request) {
+		@RequestBody AdminReservationRequest request,
+		@AuthenticationPrincipal CustomUserDetails user) {
+
+		adminReservationService.reserveClassroom(request, user.getStudentNumber());
 		return ResponseEntity.ok(new StringResponseDto("예약 완료 하였습니다."));
 	}
 

--- a/src/main/java/com/groomiz/billage/reservation/controller/AdminReservationController.java
+++ b/src/main/java/com/groomiz/billage/reservation/controller/AdminReservationController.java
@@ -20,6 +20,7 @@ import com.groomiz.billage.reservation.document.AdminReservationDeleteExceptionD
 import com.groomiz.billage.reservation.document.AdminReservationExceptionDocs;
 import com.groomiz.billage.reservation.document.AdminSearchExceptionDocs;
 import com.groomiz.billage.reservation.document.AdminbyStatusExceptionDocs;
+import com.groomiz.billage.reservation.dto.request.AdminRejectionRequest;
 import com.groomiz.billage.reservation.dto.request.AdminReservationRequest;
 import com.groomiz.billage.reservation.dto.response.AdminReservationStatusListResponse;
 import com.groomiz.billage.reservation.service.AdminReservationService;
@@ -58,10 +59,15 @@ public class AdminReservationController {
 	@PostMapping("/{id}/reject")
 	@Operation(summary = "예약 거절")
 	@ApiErrorExceptionsExample(AdminApproveRejectExceptionDocs.class)
-	//TODO: 이거 Reason 필요하면 해당 dto 만들어서 보내주세요! 임시라서 이렇게 생긴 거 같아 일단 두겠습니다!
 	public ResponseEntity<AdminReservationReasonResponse> rejectReservation(@PathVariable Long id,
-		@RequestBody(required = false) String rejectionReason) {
-		return ResponseEntity.ok(new AdminReservationReasonResponse("예약 거절 완료되었습니다.", rejectionReason));
+		@RequestBody AdminRejectionRequest request,
+		@AuthenticationPrincipal CustomUserDetails user) {
+
+		adminReservationService.rejectReservation(id, request.getReason(), user.getStudentNumber());
+
+		AdminReservationReasonResponse response = new AdminReservationReasonResponse(
+			"예약 거절 완료되었습니다.", request.getReason());
+		return ResponseEntity.ok(response);
 	}
 
 	@PostMapping

--- a/src/main/java/com/groomiz/billage/reservation/controller/AdminReservationController.java
+++ b/src/main/java/com/groomiz/billage/reservation/controller/AdminReservationController.java
@@ -25,6 +25,7 @@ import com.groomiz.billage.reservation.dto.request.AdminRejectionRequest;
 import com.groomiz.billage.reservation.dto.request.AdminReservationRequest;
 import com.groomiz.billage.reservation.dto.response.AdminReservationResponse;
 import com.groomiz.billage.reservation.dto.response.AdminReservationStatusListResponse;
+import com.groomiz.billage.reservation.entity.ReservationStatusType;
 import com.groomiz.billage.reservation.service.AdminReservationService;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -46,8 +47,15 @@ public class AdminReservationController {
 	@Operation(summary = "예약 상태별 리스트 조회")
 	@ApiErrorExceptionsExample(AdminbyStatusExceptionDocs.class)
 	public ResponseEntity<AdminReservationStatusListResponse> getReservationsByStatus(
-		@RequestParam(required = false) String status) {
-		return ResponseEntity.ok(null);
+		@Parameter(description = "예약 상태 (PENDING/APPROVED/REJECTED)", example = "APPROVED", required = true)
+		@RequestParam(required = true) String status,
+		@AuthenticationPrincipal CustomUserDetails user) {
+
+		ReservationStatusType type = ReservationStatusType.valueOf(status.toUpperCase());
+
+		AdminReservationStatusListResponse reservations = adminReservationService.getReservationByStatus(type,
+			user.getStudentNumber());
+		return ResponseEntity.ok(reservations);
 	}
 
 	@PostMapping("/{id}/approve")

--- a/src/main/java/com/groomiz/billage/reservation/controller/AdminReservationController.java
+++ b/src/main/java/com/groomiz/billage/reservation/controller/AdminReservationController.java
@@ -11,6 +11,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.google.firebase.messaging.FirebaseMessagingException;
 import com.groomiz.billage.auth.dto.CustomUserDetails;
 import com.groomiz.billage.classroom.dto.response.AdminReservationReasonResponse;
 import com.groomiz.billage.common.dto.StringResponseDto;
@@ -50,9 +51,10 @@ public class AdminReservationController {
 	@ApiErrorExceptionsExample(AdminApproveRejectExceptionDocs.class)
 	public ResponseEntity<StringResponseDto> approveReservation(
 		@PathVariable Long id,
-		@AuthenticationPrincipal CustomUserDetails user) {
+		@AuthenticationPrincipal CustomUserDetails user) throws FirebaseMessagingException {
 
 		adminReservationService.approveReservation(id, user.getStudentNumber());
+
 		return ResponseEntity.ok(new StringResponseDto("예약 승인 완료되었습니다."));
 	}
 
@@ -61,7 +63,7 @@ public class AdminReservationController {
 	@ApiErrorExceptionsExample(AdminApproveRejectExceptionDocs.class)
 	public ResponseEntity<AdminReservationReasonResponse> rejectReservation(@PathVariable Long id,
 		@RequestBody AdminRejectionRequest request,
-		@AuthenticationPrincipal CustomUserDetails user) {
+		@AuthenticationPrincipal CustomUserDetails user) throws FirebaseMessagingException {
 
 		adminReservationService.rejectReservation(id, request.getReason(), user.getStudentNumber());
 

--- a/src/main/java/com/groomiz/billage/reservation/controller/AdminReservationController.java
+++ b/src/main/java/com/groomiz/billage/reservation/controller/AdminReservationController.java
@@ -1,6 +1,7 @@
 package com.groomiz.billage.reservation.controller;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -10,6 +11,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.groomiz.billage.auth.dto.CustomUserDetails;
 import com.groomiz.billage.classroom.dto.response.AdminReservationReasonResponse;
 import com.groomiz.billage.common.dto.StringResponseDto;
 import com.groomiz.billage.global.anotation.ApiErrorExceptionsExample;
@@ -20,6 +22,7 @@ import com.groomiz.billage.reservation.document.AdminSearchExceptionDocs;
 import com.groomiz.billage.reservation.document.AdminbyStatusExceptionDocs;
 import com.groomiz.billage.reservation.dto.request.AdminReservationRequest;
 import com.groomiz.billage.reservation.dto.response.AdminReservationStatusListResponse;
+import com.groomiz.billage.reservation.service.AdminReservationService;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -30,6 +33,8 @@ import lombok.RequiredArgsConstructor;
 @Tag(name = "Admin Reservation Controller", description = "[관리자] 예약 관련 API")
 @RequiredArgsConstructor
 public class AdminReservationController {
+
+	private final AdminReservationService adminReservationService;
 
 	@GetMapping
 	@Operation(summary = "예약 상태별 리스트 조회")
@@ -42,7 +47,11 @@ public class AdminReservationController {
 	@PostMapping("/{id}/approve")
 	@Operation(summary = "예약 승인")
 	@ApiErrorExceptionsExample(AdminApproveRejectExceptionDocs.class)
-	public ResponseEntity<StringResponseDto> approveReservation(@PathVariable Long id) {
+	public ResponseEntity<StringResponseDto> approveReservation(
+		@PathVariable Long id,
+		@AuthenticationPrincipal CustomUserDetails user) {
+
+		adminReservationService.approveReservation(id, user.getStudentNumber());
 		return ResponseEntity.ok(new StringResponseDto("예약 승인 완료되었습니다."));
 	}
 

--- a/src/main/java/com/groomiz/billage/reservation/controller/ReservationController.java
+++ b/src/main/java/com/groomiz/billage/reservation/controller/ReservationController.java
@@ -1,15 +1,9 @@
 package com.groomiz.billage.reservation.controller;
 
-import java.time.LocalDate;
-import java.util.List;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.core.userdetails.UserDetails;
-import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -22,13 +16,10 @@ import com.groomiz.billage.auth.document.JwtExceptionDocs;
 import com.groomiz.billage.auth.dto.CustomUserDetails;
 import com.groomiz.billage.common.dto.StringResponseDto;
 import com.groomiz.billage.global.anotation.ApiErrorExceptionsExample;
-import com.groomiz.billage.member.exception.MemberErrorCode;
-import com.groomiz.billage.member.exception.MemberException;
 import com.groomiz.billage.reservation.document.ReservationCancelExceptionDocs;
 import com.groomiz.billage.reservation.document.ReservationExceptionDocs;
 import com.groomiz.billage.reservation.dto.request.ClassroomReservationRequest;
 import com.groomiz.billage.reservation.dto.response.ReservationStatusListResponse;
-import com.groomiz.billage.reservation.entity.ReservationPurpose;
 import com.groomiz.billage.reservation.exception.ReservationErrorCode;
 import com.groomiz.billage.reservation.exception.ReservationException;
 import com.groomiz.billage.reservation.service.ReservationService;
@@ -66,13 +57,13 @@ public class ReservationController {
 	@DeleteMapping("/{id}")
 	@Operation(summary = "강의실 예약 취소")
 	@ApiErrorExceptionsExample(ReservationCancelExceptionDocs.class)
-	public ResponseEntity<StringResponseDto> cancleReservation(
+	public ResponseEntity<StringResponseDto> cancelReservation(
 		@Parameter(description = "예약 ID", example = "1")
 		@PathVariable("id") Long id,
 		@AuthenticationPrincipal CustomUserDetails user
 	) {
 
-		reservationService.cancleReservation(id, user.getStudentNumber());
+		reservationService.cancelReservation(id, user.getStudentNumber());
 		return ResponseEntity.ok(new StringResponseDto("강의실 예약 취소에 성공하였습니다."));
 	}
 

--- a/src/main/java/com/groomiz/billage/reservation/document/AdminReservationExceptionDocs.java
+++ b/src/main/java/com/groomiz/billage/reservation/document/AdminReservationExceptionDocs.java
@@ -40,4 +40,7 @@ public class AdminReservationExceptionDocs implements SwaggerExampleExceptions {
 
 	@ExplainError("예약 시간이 24시 형식이 아닌 경우 발생하는 오류입니다.")
 	public GlobalCodeException 잘못된_시간_형식 = new ReservationException(ReservationErrorCode.INVALID_RESERVATION_TIME);
+
+	@ExplainError("이미 예약 중인 강의실에 대해 중복 예약을 시도한 경우 발생하는 오류입니다.")
+	public GlobalCodeException 중복_예약 = new ReservationException(ReservationErrorCode.DUPLICATE_RESERVATION);
 }

--- a/src/main/java/com/groomiz/billage/reservation/dto/request/AdminRejectionRequest.java
+++ b/src/main/java/com/groomiz/billage/reservation/dto/request/AdminRejectionRequest.java
@@ -1,0 +1,13 @@
+package com.groomiz.billage.reservation.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Data;
+import lombok.Getter;
+
+@Data
+@Schema(description = "예약 거절 요청 DTO")
+public class AdminRejectionRequest {
+
+	@Schema(description = "예약 거절 사유", example = "목적이 확인되지 않습니다.")
+	private String reason;
+}

--- a/src/main/java/com/groomiz/billage/reservation/dto/request/AdminReservationRequest.java
+++ b/src/main/java/com/groomiz/billage/reservation/dto/request/AdminReservationRequest.java
@@ -1,5 +1,6 @@
 package com.groomiz.billage.reservation.dto.request;
 
+import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.List;
@@ -9,7 +10,6 @@ import com.groomiz.billage.reservation.entity.ReservationType;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Pattern;
 import lombok.Data;
 
 @Data
@@ -17,7 +17,7 @@ import lombok.Data;
 public class AdminReservationRequest {
 
 	@NotNull
-	@Schema(description = "예약 타입", example = "single")
+	@Schema(description = "예약 타입", example = "일반")
 	private ReservationType type;
 
 	@NotNull
@@ -29,25 +29,23 @@ public class AdminReservationRequest {
 	private Long classroomId;
 
 	@NotNull
-	@Pattern(regexp = "\\d{4}-\\d{2}-\\d{2}", message = "날짜 형식은 yyyy-MM-dd여야 합니다.")
 	@Schema(description = "시작 날짜", example = "2024-09-03")
 	private LocalDate startDate;
 
 	@NotNull
-	@Pattern(regexp = "\\d{4}-\\d{2}-\\d{2}", message = "날짜 형식은 yyyy-MM-dd여야 합니다.")
 	@Schema(description = "종료 날짜", example = "2024-09-05")
 	private LocalDate endDate;
 
-	@Schema(description = "요일 리스트", example = "[\"Monday\", \"Wednesday\", \"Friday\"]")
-	private List<String> days;
+	@Schema(description = "요일 리스트", example = "[\"MONDAY\", \"TUESDAY\", \"FRIDAY\"]")
+	private List<DayOfWeek> days;
 
 	@NotNull
-	@Pattern(regexp = "\\d{2}-\\d{2}", message = "시간 형식은 HH:mm이어야 합니다.")
-	@Schema(description = "시작 시간", example = "9:00")
+	@Schema(description = "시작 시간", example = "9:00", type = "string")
+	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm")
 	private LocalTime startTime;
 
 	@NotNull
-	@Pattern(regexp = "\\d{2}-\\d{2}", message = "시간 형식은 HH:mm이어야 합니다.")
-	@Schema(description = "종료 시간", example = "10:00")
+	@Schema(description = "종료 시간", example = "10:00", type = "string")
+	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm")
 	private LocalTime endTime;
 }

--- a/src/main/java/com/groomiz/billage/reservation/dto/request/AdminReservationRequest.java
+++ b/src/main/java/com/groomiz/billage/reservation/dto/request/AdminReservationRequest.java
@@ -20,9 +20,9 @@ public class AdminReservationRequest {
 	@Schema(description = "예약 타입", example = "일반")
 	private ReservationType type;
 
-	@NotNull
-	@Schema(description = "건물 ID", example = "1")
-	private Long buildingId;
+	// @NotNull
+	// @Schema(description = "건물 ID", example = "1")
+	// private Long buildingId;
 
 	@NotNull
 	@Schema(description = "강의실 ID", example = "1")
@@ -40,7 +40,7 @@ public class AdminReservationRequest {
 	private List<DayOfWeek> days;
 
 	@NotNull
-	@Schema(description = "시작 시간", example = "9:00", type = "string")
+	@Schema(description = "시작 시간", example = "09:00", type = "string")
 	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm")
 	private LocalTime startTime;
 

--- a/src/main/java/com/groomiz/billage/reservation/dto/response/AdminReservationResponse.java
+++ b/src/main/java/com/groomiz/billage/reservation/dto/response/AdminReservationResponse.java
@@ -3,20 +3,21 @@ package com.groomiz.billage.reservation.dto.response;
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.groomiz.billage.reservation.entity.ReservationPurpose;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import lombok.AllArgsConstructor;
+import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
 @Data
-@Builder
-@NoArgsConstructor
-@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Schema(description = "예약 상세 조회 응답 DTO")
 public class AdminReservationResponse {
 
@@ -33,17 +34,35 @@ public class AdminReservationResponse {
 	private String classroomName;
 
 	@Schema(description = "전화번호 목록", example = "[\"010-1234-1234\", \"010-5678-5678\"]")
-	private List<String> phoneNumber;
+	private List<String> phoneNumbers;
 
 	@Schema(description = "예약 목적", example = "동아리 행사")
 	private ReservationPurpose purpose;
 
-	@Schema(description = "예약 시작 시간", example = "9:00")
+	@Schema(description = "예약 시작 시간", example = "09:00")
+	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm")
 	private LocalTime startTime;
 
 	@Schema(description = "예약 종료 시간", example = "10:00")
+	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm")
 	private LocalTime endTime;
 
 	@Schema(description = "비고 내용", example = "비고 내용입니다.")
 	private String contents;
+
+	@Builder
+	public AdminReservationResponse(LocalDate date, Integer headcount, String buildingName, String classroomName,
+		String phoneNumber1, String phoneNumber2, ReservationPurpose purpose, LocalTime startTime, LocalTime endTime, String contents) {
+		this.date = date;
+		this.headcount = headcount;
+		this.buildingName = buildingName;
+		this.classroomName = classroomName;
+		this.phoneNumbers = Stream.of(phoneNumber1, phoneNumber2)
+			.filter(Objects::nonNull)
+			.collect(Collectors.toList());
+		this.purpose = purpose;
+		this.startTime = startTime;
+		this.endTime = endTime;
+		this.contents = contents;
+	}
 }

--- a/src/main/java/com/groomiz/billage/reservation/dto/response/AdminReservationStatusListResponse.java
+++ b/src/main/java/com/groomiz/billage/reservation/dto/response/AdminReservationStatusListResponse.java
@@ -4,16 +4,18 @@ import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.List;
 
-import com.fasterxml.jackson.annotation.JsonFormat;
+import com.groomiz.billage.reservation.entity.Reservation;
+import com.groomiz.billage.reservation.entity.ReservationStatusType;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
 import lombok.Data;
 
 @Data
 @Schema(description = "예약 상태별 조회 응답 DTO")
 public class AdminReservationStatusListResponse {
-	@Schema(description = "예약 상태", example = "pending")
-	private String status;
+	@Schema(description = "예약 상태", example = "예약 대기")
+	private ReservationStatusType status;
 
 	@Schema(description = "예약 목록")
 	private List<ReservationInfo> reservations;
@@ -46,9 +48,56 @@ public class AdminReservationStatusListResponse {
 		private String classroomName;
 
 		@Schema(description = "학생 이름", example = "홍길동")
-		private String memberName;
+		private String studentName;
 
-		@Schema(description = "학생 ID", example = "20201234")
-		private String studentId;
+		@Schema(description = "학번", example = "20201234")
+		private String studentNumber;
+
+		@Builder
+		public ReservationInfo(Long reservationId, LocalDate date, LocalTime startTime, LocalTime endTime,
+			Integer headcount,
+			String buildingName, Long floor, String classroomName, String studentName, String studentNumber) {
+			this.reservationId = reservationId;
+			this.date = date;
+			this.startTime = startTime;
+			this.endTime = endTime;
+			this.headcount = headcount;
+			this.buildingName = buildingName;
+			this.floor = floor;
+			this.classroomName = classroomName;
+			this.studentName = studentName;
+			this.studentNumber = studentNumber;
+		}
+
+		public static ReservationInfo from(Reservation reservation) {
+			return ReservationInfo.builder()
+				.reservationId(reservation.getId())
+				.date(reservation.getApplyDate())
+				.startTime(reservation.getStartTime())
+				.endTime(reservation.getEndTime())
+				.headcount(reservation.getHeadcount())
+				.buildingName(reservation.getClassroom().getBuilding().getName())
+				.floor(reservation.getClassroom().getFloor())
+				.classroomName(reservation.getClassroom().getName())
+				.studentName(reservation.getReservationStatus().getRequester().getUsername())
+				.studentNumber(reservation.getReservationStatus().getRequester().getStudentNumber())
+				.build();
+
+		}
+	}
+
+	@Builder
+	public AdminReservationStatusListResponse(ReservationStatusType status, List<ReservationInfo> reservations) {
+		this.status = status;
+		this.reservations = reservations;
+	}
+
+	public static AdminReservationStatusListResponse from(ReservationStatusType status, List<Reservation> reservations) {
+		return AdminReservationStatusListResponse.builder()
+			.status(status)
+			.reservations(reservations.stream()
+				.map(ReservationInfo::from)
+				.toList())
+			.build();
 	}
 }

--- a/src/main/java/com/groomiz/billage/reservation/entity/Reservation.java
+++ b/src/main/java/com/groomiz/billage/reservation/entity/Reservation.java
@@ -2,13 +2,10 @@ package com.groomiz.billage.reservation.entity;
 
 import java.time.LocalDate;
 import java.time.LocalTime;
-import java.util.ArrayList;
-import java.util.List;
 
 import com.groomiz.billage.classroom.entity.Classroom;
 import com.groomiz.billage.common.entity.BaseEntity;
 
-import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -19,7 +16,6 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
-import jakarta.persistence.OneToMany;
 import jakarta.persistence.OneToOne;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -38,7 +34,7 @@ public class Reservation extends BaseEntity {
 	@Column(name = "apply_date", nullable = false)
 	private LocalDate applyDate;
 
-	@Column(nullable = false)
+	@Column
 	private Integer headcount;
 
 	@Column(name = "start_time", nullable = false)
@@ -48,10 +44,9 @@ public class Reservation extends BaseEntity {
 	private LocalTime endTime;
 
 	@Enumerated(EnumType.STRING)
-	@Column(nullable = false)
 	private ReservationPurpose purpose;
 
-	@Column(name = "phone_number", nullable = false)
+	@Column(name = "phone_number")
 	private String phoneNumber;
 
 	private String contents;
@@ -64,10 +59,18 @@ public class Reservation extends BaseEntity {
 	@JoinColumn(name = "reservation_status_id", nullable = false)
 	private ReservationStatus reservationStatus;
 
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "reservaion_group_id")
+	private ReservationGroup group;
+
+	public void setGroup(ReservationGroup group) {
+		this.group = group;
+	}
+
 	@Builder
 	public Reservation(LocalDate applyDate, Integer headcount, LocalTime startTime, LocalTime endTime,
 		ReservationPurpose purpose, String phoneNumber, String contents, Classroom classroom,
-		ReservationStatus reservationStatus) {
+		ReservationStatus reservationStatus, ReservationGroup group) {
 		this.applyDate = applyDate;
 		this.headcount = headcount;
 		this.startTime = startTime;
@@ -77,5 +80,6 @@ public class Reservation extends BaseEntity {
 		this.contents = contents;
 		this.classroom = classroom;
 		this.reservationStatus = reservationStatus;
+		this.group = group;
 	}
 }

--- a/src/main/java/com/groomiz/billage/reservation/entity/ReservationGroup.java
+++ b/src/main/java/com/groomiz/billage/reservation/entity/ReservationGroup.java
@@ -1,0 +1,26 @@
+package com.groomiz.billage.reservation.entity;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class ReservationGroup {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@OneToMany(mappedBy = "group", cascade = CascadeType.PERSIST)
+	private List<Reservation> reservations = new ArrayList<>();
+}

--- a/src/main/java/com/groomiz/billage/reservation/entity/ReservationStatus.java
+++ b/src/main/java/com/groomiz/billage/reservation/entity/ReservationStatus.java
@@ -15,6 +15,7 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToOne;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -46,6 +47,13 @@ public class ReservationStatus extends BaseEntity {
 	private Reservation reservation;
 
 	public ReservationStatus (Member requester) {
+		this.requester = requester;
+	}
+
+	@Builder
+	public ReservationStatus(ReservationStatusType status, Member requester) {
+		this.status = status;
+		this.admin = requester;
 		this.requester = requester;
 	}
 

--- a/src/main/java/com/groomiz/billage/reservation/entity/ReservationStatus.java
+++ b/src/main/java/com/groomiz/billage/reservation/entity/ReservationStatus.java
@@ -1,7 +1,5 @@
 package com.groomiz.billage.reservation.entity;
 
-import org.hibernate.annotations.ColumnDefault;
-
 import com.groomiz.billage.common.entity.BaseEntity;
 import com.groomiz.billage.member.entity.Member;
 
@@ -17,8 +15,6 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToOne;
 import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -57,6 +53,25 @@ public class ReservationStatus extends BaseEntity {
 		this.status = status;
 	}
 
+	public void approve(Member admin) {
+		this.status = ReservationStatusType.APPROVED;
+		this.admin = admin;
+	}
+
+	public void reject(Member admin) {
+		this.status = ReservationStatusType.REJECTED;
+		this.admin = admin;
+	}
+
+	public void cancelByStudent() {
+		this.status = ReservationStatusType.STUDENT_CANCELED;
+	}
+
+	public void cancelByAdmin(Member admin) {
+		this.status = ReservationStatusType.ADMIN_CANCELED;
+		this.admin = admin;
+	}
+
 	public boolean isApproved() {
 		return this.status == ReservationStatusType.APPROVED;
 	}
@@ -69,11 +84,11 @@ public class ReservationStatus extends BaseEntity {
 		return this.status == ReservationStatusType.REJECTED;
 	}
 
-	public boolean isStudentCanceled() {
+	public boolean isCanceledByStudent() {
 		return this.status == ReservationStatusType.STUDENT_CANCELED;
 	}
 
-	public boolean isAdminCanceled() {
+	public boolean isCanceledByAdmin() {
 		return this.status == ReservationStatusType.ADMIN_CANCELED;
 	}
 }

--- a/src/main/java/com/groomiz/billage/reservation/entity/ReservationStatus.java
+++ b/src/main/java/com/groomiz/billage/reservation/entity/ReservationStatus.java
@@ -58,8 +58,9 @@ public class ReservationStatus extends BaseEntity {
 		this.admin = admin;
 	}
 
-	public void reject(Member admin) {
+	public void reject(Member admin, String rejectionReason) {
 		this.status = ReservationStatusType.REJECTED;
+		this.rejectionReason = rejectionReason;
 		this.admin = admin;
 	}
 

--- a/src/main/java/com/groomiz/billage/reservation/entity/ReservationStatus.java
+++ b/src/main/java/com/groomiz/billage/reservation/entity/ReservationStatus.java
@@ -69,11 +69,11 @@ public class ReservationStatus extends BaseEntity {
 		return this.status == ReservationStatusType.REJECTED;
 	}
 
-	public boolean isStudentCancled() {
-		return this.status == ReservationStatusType.STUDENT_CANCLED;
+	public boolean isStudentCanceled() {
+		return this.status == ReservationStatusType.STUDENT_CANCELED;
 	}
 
-	public boolean isAdminCancled() {
-		return this.status == ReservationStatusType.ADMIN_CANCLED;
+	public boolean isAdminCanceled() {
+		return this.status == ReservationStatusType.ADMIN_CANCELED;
 	}
 }

--- a/src/main/java/com/groomiz/billage/reservation/entity/ReservationStatusType.java
+++ b/src/main/java/com/groomiz/billage/reservation/entity/ReservationStatusType.java
@@ -5,6 +5,8 @@ import java.util.Map;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
+import com.groomiz.billage.reservation.exception.ReservationErrorCode;
+import com.groomiz.billage.reservation.exception.ReservationException;
 
 import lombok.RequiredArgsConstructor;
 
@@ -36,7 +38,7 @@ public enum ReservationStatusType {
 		ReservationStatusType type = NAME_TO_ENUM_MAP.get(name);
 
 		if (type == null) {
-			// TODO: 예외 처리
+			throw new ReservationException(ReservationErrorCode.INVALID_RESERVATION_STATUS_TYPE);
 		}
 
 		return type;

--- a/src/main/java/com/groomiz/billage/reservation/entity/ReservationStatusType.java
+++ b/src/main/java/com/groomiz/billage/reservation/entity/ReservationStatusType.java
@@ -13,8 +13,8 @@ public enum ReservationStatusType {
 	APPROVED("예약 승인"),
 	PENDING("예약 대기"),
 	REJECTED("예약 거절"),
-	STUDENT_CANCLED("학생 취소"),
-	ADMIN_CANCLED("관리자 취소");
+	STUDENT_CANCELED("학생 취소"),
+	ADMIN_CANCELED("관리자 취소");
 
 	private final String name;
 

--- a/src/main/java/com/groomiz/billage/reservation/entity/ReservationType.java
+++ b/src/main/java/com/groomiz/billage/reservation/entity/ReservationType.java
@@ -5,6 +5,8 @@ import java.util.Map;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
+import com.groomiz.billage.reservation.exception.AdminReservationErrorCode;
+import com.groomiz.billage.reservation.exception.AdminReservationException;
 
 import lombok.RequiredArgsConstructor;
 
@@ -34,7 +36,7 @@ public enum ReservationType {
 		ReservationType type = NAME_TO_ENUM_MAP.get(name);
 
 		if (type == null) {
-			// TODO: 예외 처리
+			throw new AdminReservationException(AdminReservationErrorCode.INVALID_RESERVATION_TYPE);
 		}
 
 		return type;

--- a/src/main/java/com/groomiz/billage/reservation/exception/AdminReservationErrorCode.java
+++ b/src/main/java/com/groomiz/billage/reservation/exception/AdminReservationErrorCode.java
@@ -26,7 +26,10 @@ public enum AdminReservationErrorCode implements BaseErrorCode {
 	MISSING_RESERVATION_TYPE(BAD_REQUEST, "ADMIN_RESERVATION_400_4", "예약 유형 값이 올바르지 않습니다. 허용되는 값은 '일반', '기간', '반복'입니다."),
 
 	@ExplainError("이미 예약 대기 상태 혹은 승인된 강의실인 경우 발생하는 오류입니다.")
-	DUPLICATE_RESERVATION(BAD_REQUEST, "ADMIN_RESERVATION_400_5", "이미 예약 대기 상태 혹은 승인된 강의실입니다.");
+	DUPLICATE_RESERVATION(BAD_REQUEST, "ADMIN_RESERVATION_400_5", "이미 예약 대기 상태 혹은 승인된 강의실입니다."),
+
+	@ExplainError("예약 그룹이 존재하지 않을 때 발생하는 오류입니다.")
+	RESERVATION_GROUP_NOT_FOUND(NOT_FOUND, "ADMIN_RESERVATION_404_1", "예약 그룹이 존재하지 않습니다.");
 
 	private final Integer status;
 	private final String code;

--- a/src/main/java/com/groomiz/billage/reservation/exception/AdminReservationErrorCode.java
+++ b/src/main/java/com/groomiz/billage/reservation/exception/AdminReservationErrorCode.java
@@ -14,7 +14,7 @@ import lombok.Getter;
 public enum AdminReservationErrorCode implements BaseErrorCode {
 
 	@ExplainError("예약 타입이 유효하지 않을 때 발생하는 오류입니다.")
-	INVALID_STATUS_FORMAT(BAD_REQUEST, "ADMIN_RESERVATION_400_1", "예약 상태 값이 올바르지 않습니다. 허용되는 값은 'pending', 'approve', 'reject'입니다."),
+	INVALID_STATUS_FORMAT(BAD_REQUEST, "ADMIN_RESERVATION_400_1", "예약 상태 값이 올바르지 않습니다. 허용되는 값은 '대기', '승인', '거절'입니다."),
 
 	@ExplainError("예약 타입 파라미터가 누락되었을 때 발생하는 오류입니다.")
 	MISSING_STATUS_PARAMETER(BAD_REQUEST, "ADMIN_RESERVATION_400_2", "예약 상태 파라미터가 필요합니다."),
@@ -23,7 +23,10 @@ public enum AdminReservationErrorCode implements BaseErrorCode {
 	INVALID_RESERVATION_TYPE(BAD_REQUEST, "ADMIN_RESERVATION_400_3", "예약 유형 값이 올바르지 않습니다. 허용되는 값은 '일반', '기간', '반복'입니다."),
 
 	@ExplainError("예약 유형 값이 누락되었을 때 발생하는 오류입니다.")
-	MISSING_RESERVATION_TYPE(BAD_REQUEST, "ADMIN_RESERVATION_400_4", "예약 유형 값이 올바르지 않습니다. 허용되는 값은 'single', 'period', 'recurring'입니다.");
+	MISSING_RESERVATION_TYPE(BAD_REQUEST, "ADMIN_RESERVATION_400_4", "예약 유형 값이 올바르지 않습니다. 허용되는 값은 '일반', '기간', '반복'입니다."),
+
+	@ExplainError("이미 예약 대기 상태 혹은 승인된 강의실인 경우 발생하는 오류입니다.")
+	DUPLICATE_RESERVATION(BAD_REQUEST, "ADMIN_RESERVATION_400_5", "이미 예약 대기 상태 혹은 승인된 강의실입니다.");
 
 	private final Integer status;
 	private final String code;

--- a/src/main/java/com/groomiz/billage/reservation/exception/AdminReservationErrorCode.java
+++ b/src/main/java/com/groomiz/billage/reservation/exception/AdminReservationErrorCode.java
@@ -20,7 +20,7 @@ public enum AdminReservationErrorCode implements BaseErrorCode {
 	MISSING_STATUS_PARAMETER(BAD_REQUEST, "ADMIN_RESERVATION_400_2", "예약 상태 파라미터가 필요합니다."),
 
 	@ExplainError("예약 유형 값이 올바르지 않을 때 발생하는 오류입니다.")
-	INVALID_RESERVATION_TYPE(BAD_REQUEST, "ADMIN_RESERVATION_400_3", "예약 유형 값이 올바르지 않습니다. 허용되는 값은 'single', 'period', 'recurring'입니다."),
+	INVALID_RESERVATION_TYPE(BAD_REQUEST, "ADMIN_RESERVATION_400_3", "예약 유형 값이 올바르지 않습니다. 허용되는 값은 '일반', '기간', '반복'입니다."),
 
 	@ExplainError("예약 유형 값이 누락되었을 때 발생하는 오류입니다.")
 	MISSING_RESERVATION_TYPE(BAD_REQUEST, "ADMIN_RESERVATION_400_4", "예약 유형 값이 올바르지 않습니다. 허용되는 값은 'single', 'period', 'recurring'입니다.");

--- a/src/main/java/com/groomiz/billage/reservation/exception/AdminReservationErrorCode.java
+++ b/src/main/java/com/groomiz/billage/reservation/exception/AdminReservationErrorCode.java
@@ -29,7 +29,10 @@ public enum AdminReservationErrorCode implements BaseErrorCode {
 	DUPLICATE_RESERVATION(BAD_REQUEST, "ADMIN_RESERVATION_400_5", "이미 예약 대기 상태 혹은 승인된 강의실입니다."),
 
 	@ExplainError("예약 그룹이 존재하지 않을 때 발생하는 오류입니다.")
-	RESERVATION_GROUP_NOT_FOUND(NOT_FOUND, "ADMIN_RESERVATION_404_1", "예약 그룹이 존재하지 않습니다.");
+	RESERVATION_GROUP_NOT_FOUND(NOT_FOUND, "ADMIN_RESERVATION_404_1", "예약 그룹이 존재하지 않습니다."),
+
+	@ExplainError("관리자가 관리하는 건물이 존재하지 않을 때 발생하는 오류입니다.")
+	BUILDING_ADMIN_NOT_FOUND(NOT_FOUND, "ADMIN_RESERVATION_404_2", "관리자가 관리하는 건물이 존재하지 않습니다.");
 
 	private final Integer status;
 	private final String code;

--- a/src/main/java/com/groomiz/billage/reservation/exception/ReservationErrorCode.java
+++ b/src/main/java/com/groomiz/billage/reservation/exception/ReservationErrorCode.java
@@ -62,7 +62,10 @@ public enum ReservationErrorCode implements BaseErrorCode {
 	DUPLICATE_RESERVATION(BAD_REQUEST, "RESERVATION_400_14", "이미 예약 대기 상태 혹은 승인된 강의실입니다."),
 
 	@ExplainError("예약이 이미 취소된 경우 발생하는 오류입니다.")
-	RESERVATION_ALREADY_CANCELED(BAD_REQUEST, "RESERVATION_400_15", "이미 취소된 예약입니다.");
+	RESERVATION_ALREADY_CANCELED(BAD_REQUEST, "RESERVATION_400_15", "이미 취소된 예약입니다."),
+
+	@ExplainError("예약 상태가 잘못된 형식인 경우 발생하는 오류입니다.")
+	INVALID_RESERVATION_STATUS_TYPE(BAD_REQUEST, "RESERVATION_400_16", "예약 상태가 잘못된 형식입니다.");
 
 
 	private final Integer status;

--- a/src/main/java/com/groomiz/billage/reservation/exception/ReservationErrorCode.java
+++ b/src/main/java/com/groomiz/billage/reservation/exception/ReservationErrorCode.java
@@ -39,7 +39,7 @@ public enum ReservationErrorCode implements BaseErrorCode {
 
 	@ExplainError("예약이 이미 삭제된 경우 발생하는 오류입니다.")
 	RESERVATION_ALREADY_DELETED(BAD_REQUEST, "RESERVATION_400_7", "이미 삭제된 예약입니다."),
-
+	
 	@ExplainError("예약 시간이 24시 형식이 아닌 경우 발생하는 오류입니다.")
 	INVALID_RESERVATION_TIME(BAD_REQUEST, "RESERVATION_400_8", "예약 시간은 24시 형식이어야 합니다."),
 
@@ -59,7 +59,11 @@ public enum ReservationErrorCode implements BaseErrorCode {
 	INVALID_RESERVATION_DATE(BAD_REQUEST, "RESERVATION_400_13", "예약 날짜는 yyyy-MM-dd 형식이어야 합니다."),
 
 	@ExplainError("이미 예약 대기 상태 혹은 승인된 강의실인 경우 발생하는 오류입니다.")
-	DUPLICATE_RESERVATION(BAD_REQUEST, "RESERVATION_400_14", "이미 예약 대기 상태 혹은 승인된 강의실입니다.");
+	DUPLICATE_RESERVATION(BAD_REQUEST, "RESERVATION_400_14", "이미 예약 대기 상태 혹은 승인된 강의실입니다."),
+
+	@ExplainError("예약이 이미 취소된 경우 발생하는 오류입니다.")
+	RESERVATION_ALREADY_CANCELED(BAD_REQUEST, "RESERVATION_400_15", "이미 취소된 예약입니다.");
+
 
 	private final Integer status;
 	private final String code;

--- a/src/main/java/com/groomiz/billage/reservation/repository/ReservationGroupRepository.java
+++ b/src/main/java/com/groomiz/billage/reservation/repository/ReservationGroupRepository.java
@@ -1,0 +1,8 @@
+package com.groomiz.billage.reservation.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.groomiz.billage.reservation.entity.ReservationGroup;
+
+public interface ReservationGroupRepository extends JpaRepository<ReservationGroup, Long> {
+}

--- a/src/main/java/com/groomiz/billage/reservation/repository/ReservationRepository.java
+++ b/src/main/java/com/groomiz/billage/reservation/repository/ReservationRepository.java
@@ -41,6 +41,9 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long> 
 	@Query("SELECT r "
 		+ "FROM Reservation r "
 		+ "JOIN FETCH r.reservationStatus rs "
+		+ "JOIN FETCH r.classroom c "
+		+ "JOIN FETCH c.building b "
+		+ "JOIN FETCH rs.requester m "
 		+ "WHERE rs.status = 'APPROVED'"
 		+ "AND rs.admin = :admin")
 	List<Reservation> findApprovedReservationsWithReservationStatusByAdmin(Member admin);
@@ -48,6 +51,9 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long> 
 	@Query("SELECT r "
 		+ "FROM Reservation r "
 		+ "JOIN FETCH r.reservationStatus rs "
+		+ "JOIN FETCH r.classroom c "
+		+ "JOIN FETCH c.building b "
+		+ "JOIN FETCH rs.requester m "
 		+ "WHERE rs.status IN ('REJECTED', 'ADMIN_CANCELED', 'STUDENT_CANCELED') "
 		+ "AND rs.admin = :admin")
 	List<Reservation> findRejectedCanceledReservationsWithReservationStatusByAdmin(@Param("admin") Member admin);

--- a/src/main/java/com/groomiz/billage/reservation/repository/ReservationRepository.java
+++ b/src/main/java/com/groomiz/billage/reservation/repository/ReservationRepository.java
@@ -57,4 +57,12 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long> 
 		+ "WHERE rs.status IN ('REJECTED', 'ADMIN_CANCELED', 'STUDENT_CANCELED') "
 		+ "AND rs.admin = :admin")
 	List<Reservation> findRejectedCanceledReservationsWithReservationStatusByAdmin(@Param("admin") Member admin);
+
+	@Query("SELECT DISTINCT r "
+	+ "FROM Reservation r "
+	+ "JOIN FETCH r.reservationStatus rs "
+	+ "WHERE r.classroom.id in :classroomIds "
+	+ "AND r.applyDate = :date "
+	+ "AND rs.status IN ('PENDING', 'APPROVED')")
+	List<Reservation> findReservationsByClassroomIdsAndDate(List<Long> classroomIds, LocalDate date);
 }

--- a/src/main/java/com/groomiz/billage/reservation/repository/ReservationRepository.java
+++ b/src/main/java/com/groomiz/billage/reservation/repository/ReservationRepository.java
@@ -2,12 +2,13 @@ package com.groomiz.billage.reservation.repository;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
 
-import org.hibernate.annotations.Parameter;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
 import com.groomiz.billage.classroom.dto.ReservationTime;
+import com.groomiz.billage.reservation.dto.response.AdminReservationResponse;
 import com.groomiz.billage.reservation.entity.Reservation;
 
 import io.lettuce.core.dynamic.annotation.Param;
@@ -21,4 +22,11 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long> 
 		+ "AND r.classroom.id = :classroomId")
 	List<ReservationTime> findPendingOrApprovedReservationsByDateAndClassroom(@Param("applyDate") LocalDate applyDate, @Param("classroomId") Long classroomId);
 
+	@Query("SELECT new com.groomiz.billage.reservation.dto.response.AdminReservationResponse(r.applyDate, r.headcount, b.name, c.name, rs.requester.phoneNumber ,r.phoneNumber, r.purpose, r.startTime, r.endTime,r.contents) "
+		+ "FROM Reservation r "
+		+ "JOIN r.classroom c "
+		+ "JOIN c.building b "
+		+ "JOIN r.reservationStatus rs "
+		+ "WHERE r.id = :reservationId")
+	Optional<AdminReservationResponse> findAdminReservationResponseById(@Param("reservationId") Long reservationId);
 }

--- a/src/main/java/com/groomiz/billage/reservation/repository/ReservationRepository.java
+++ b/src/main/java/com/groomiz/billage/reservation/repository/ReservationRepository.java
@@ -8,6 +8,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
 import com.groomiz.billage.classroom.dto.ReservationTime;
+import com.groomiz.billage.member.entity.Member;
 import com.groomiz.billage.reservation.dto.response.AdminReservationResponse;
 import com.groomiz.billage.reservation.entity.Reservation;
 
@@ -29,4 +30,25 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long> 
 		+ "JOIN r.reservationStatus rs "
 		+ "WHERE r.id = :reservationId")
 	Optional<AdminReservationResponse> findAdminReservationResponseById(@Param("reservationId") Long reservationId);
+
+	@Query("SELECT r "
+	+ "FROM Reservation r "
+	+ "JOIN FETCH r.reservationStatus rs "
+	+ "WHERE rs.status = 'PENDING'"
+	+ "AND r.classroom.building.id in :buildingIds")
+	List<Reservation> findPendingReservationsWithReservationStatusByBuildingIds(List<Long> buildingIds);
+
+	@Query("SELECT r "
+		+ "FROM Reservation r "
+		+ "JOIN FETCH r.reservationStatus rs "
+		+ "WHERE rs.status = 'APPROVED'"
+		+ "AND rs.admin = :admin")
+	List<Reservation> findApprovedReservationsWithReservationStatusByAdmin(Member admin);
+
+	@Query("SELECT r "
+		+ "FROM Reservation r "
+		+ "JOIN FETCH r.reservationStatus rs "
+		+ "WHERE rs.status IN ('REJECTED', 'ADMIN_CANCELED', 'STUDENT_CANCELED') "
+		+ "AND rs.admin = :admin")
+	List<Reservation> findRejectedCanceledReservationsWithReservationStatusByAdmin(@Param("admin") Member admin);
 }

--- a/src/main/java/com/groomiz/billage/reservation/repository/ReservationStatusRepository.java
+++ b/src/main/java/com/groomiz/billage/reservation/repository/ReservationStatusRepository.java
@@ -3,10 +3,11 @@ package com.groomiz.billage.reservation.repository;
 import java.util.List;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 
 import com.groomiz.billage.member.entity.Member;
-import com.groomiz.billage.reservation.dto.response.ReservationStatusListResponse;
+import com.groomiz.billage.reservation.entity.ReservationGroup;
 import com.groomiz.billage.reservation.entity.ReservationStatus;
 
 public interface ReservationStatusRepository extends JpaRepository<ReservationStatus, Long> {
@@ -18,4 +19,16 @@ public interface ReservationStatusRepository extends JpaRepository<ReservationSt
 		"WHERE rs.requester = :requester")
 	List<ReservationStatus> findAllFetchJoinReservationByRequester(Member requester);
 
+	@Query("SELECT rs "
+		+ "FROM ReservationStatus rs "
+		+ "JOIN FETCH rs.reservation r "
+		+ "WHERE r.group = :group")
+	List<ReservationStatus> findReservationStatusWithReservationByReservationGroup(ReservationGroup group);
+
+	// 기간/반복 예약 일괄 관리자 취소로 변경하는 쿼리
+	@Modifying
+	@Query("UPDATE ReservationStatus rs " +
+		"SET rs.status = 'ADMIN_CANCELED', rs.admin.id = :adminId " +
+		"WHERE rs IN :statuses")
+	void cancelAllByAdmin(List<ReservationStatus> statuses, Long adminId);
 }

--- a/src/main/java/com/groomiz/billage/reservation/service/AdminReservationService.java
+++ b/src/main/java/com/groomiz/billage/reservation/service/AdminReservationService.java
@@ -1,33 +1,39 @@
 package com.groomiz.billage.reservation.service;
 
+import java.util.Objects;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import com.groomiz.billage.auth.dto.CustomUserDetails;
+import com.google.firebase.messaging.FirebaseMessaging;
+import com.google.firebase.messaging.FirebaseMessagingException;
+import com.google.firebase.messaging.Message;
+import com.google.firebase.messaging.Notification;
+import com.groomiz.billage.auth.service.RedisService;
 import com.groomiz.billage.member.entity.Member;
 import com.groomiz.billage.member.exception.MemberErrorCode;
 import com.groomiz.billage.member.exception.MemberException;
 import com.groomiz.billage.member.repository.MemberRepository;
-import com.groomiz.billage.reservation.dto.request.AdminRejectionRequest;
 import com.groomiz.billage.reservation.entity.Reservation;
-import com.groomiz.billage.reservation.entity.ReservationStatus;
 import com.groomiz.billage.reservation.entity.ReservationStatusType;
 import com.groomiz.billage.reservation.exception.ReservationErrorCode;
 import com.groomiz.billage.reservation.exception.ReservationException;
 import com.groomiz.billage.reservation.repository.ReservationRepository;
-import com.groomiz.billage.reservation.repository.ReservationStatusRepository;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 @Service
 @RequiredArgsConstructor
 @Transactional
+@Slf4j
 public class AdminReservationService {
 
 	private final MemberRepository memberRepository;
 	private final ReservationRepository reservationRepository;
+	private final RedisService redisService;
 
-	public void approveReservation(Long reservationId, String studentNumber) {
+	public void approveReservation(Long reservationId, String studentNumber) throws FirebaseMessagingException {
 
 		Member admin = memberRepository.findByStudentNumber(studentNumber)
 			.orElseThrow(() -> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND));
@@ -48,9 +54,21 @@ public class AdminReservationService {
 			default:
 				throw new ReservationException(ReservationErrorCode.RESERVATION_ALREADY_CANCELED);
 		}
+
+
+		// 예약자 푸시 알림
+		Member requester = reservation.getReservationStatus().getRequester();
+
+		String title = "예약 승인 완료";
+		String body = reservation.getApplyDate().toString() + " "
+			+ reservation.getStartTime().toString() + "-" + reservation.getEndTime().toString()
+			+ " 예약이 승인되었습니다.";
+
+		sendMessage(requester.getStudentNumber(), title, body);
 	}
 
-	public void rejectReservation(Long reservationId, String rejectionReason, String studentNumber) {
+	public void rejectReservation(Long reservationId, String rejectionReason, String studentNumber) throws
+		FirebaseMessagingException {
 
 		Member admin = memberRepository.findByStudentNumber(studentNumber)
 			.orElseThrow(() -> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND));
@@ -71,5 +89,34 @@ public class AdminReservationService {
 			default:
 				throw new ReservationException(ReservationErrorCode.RESERVATION_ALREADY_CANCELED);
 		}
+
+		// 예약자 푸시 알림
+		Member requester = reservation.getReservationStatus().getRequester();
+
+		String title = "예약 거절";
+		String body = reservation.getApplyDate().toString() + " "
+			+ reservation.getStartTime().toString() + "-" + reservation.getEndTime().toString()
+			+ " 예약이 거절되었습니다.";
+
+		sendMessage(requester.getStudentNumber(), title, body);
+	}
+
+	private void sendMessage(String studentNumber, String title, String body) throws FirebaseMessagingException {
+		String key = "FCM_" + studentNumber;
+		String token = redisService.getValues(key);
+
+		if (Objects.equals(token, "false")) {
+			throw new MemberException(MemberErrorCode.FCM_TOKEN_NOT_FOUND);
+		}
+
+		Message message = Message.builder()
+			.setNotification(Notification.builder()
+				.setTitle(title)
+				.setBody(body)
+				.build())
+			.setToken(token)
+			.build();
+
+		FirebaseMessaging.getInstance().send(message);
 	}
 }

--- a/src/main/java/com/groomiz/billage/reservation/service/AdminReservationService.java
+++ b/src/main/java/com/groomiz/billage/reservation/service/AdminReservationService.java
@@ -352,6 +352,7 @@ public class AdminReservationService {
 		reservation.getReservationStatus().cancelByAdmin(admin);
 	}
 
+	@Transactional(readOnly = true)
 	public AdminReservationStatusListResponse getReservationByStatus(ReservationStatusType status, String studentNumber) {
 
 		Member admin = memberRepository.findByStudentNumber(studentNumber)

--- a/src/main/java/com/groomiz/billage/reservation/service/AdminReservationService.java
+++ b/src/main/java/com/groomiz/billage/reservation/service/AdminReservationService.java
@@ -301,4 +301,11 @@ public class AdminReservationService {
 		reservationGroupRepository.save(group);
 	}
 
+
+	@Transactional(readOnly = true)
+	public AdminReservationResponse getReservation(Long reservationId) {
+
+		return reservationRepository.findAdminReservationResponseById(reservationId)
+			.orElseThrow(() -> new ReservationException(ReservationErrorCode.RESERVATION_NOT_FOUND));
+	}
 }

--- a/src/main/java/com/groomiz/billage/reservation/service/AdminReservationService.java
+++ b/src/main/java/com/groomiz/billage/reservation/service/AdminReservationService.java
@@ -1,0 +1,52 @@
+package com.groomiz.billage.reservation.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.groomiz.billage.auth.dto.CustomUserDetails;
+import com.groomiz.billage.member.entity.Member;
+import com.groomiz.billage.member.exception.MemberErrorCode;
+import com.groomiz.billage.member.exception.MemberException;
+import com.groomiz.billage.member.repository.MemberRepository;
+import com.groomiz.billage.reservation.dto.request.AdminRejectionRequest;
+import com.groomiz.billage.reservation.entity.Reservation;
+import com.groomiz.billage.reservation.entity.ReservationStatus;
+import com.groomiz.billage.reservation.entity.ReservationStatusType;
+import com.groomiz.billage.reservation.exception.ReservationErrorCode;
+import com.groomiz.billage.reservation.exception.ReservationException;
+import com.groomiz.billage.reservation.repository.ReservationRepository;
+import com.groomiz.billage.reservation.repository.ReservationStatusRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class AdminReservationService {
+
+	private final MemberRepository memberRepository;
+	private final ReservationRepository reservationRepository;
+
+	public void approveReservation(Long reservationId, String studentNumber) {
+
+		Member admin = memberRepository.findByStudentNumber(studentNumber)
+			.orElseThrow(() -> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND));
+
+		Reservation reservation = reservationRepository.findById(reservationId)
+			.orElseThrow(() -> new ReservationException(ReservationErrorCode.RESERVATION_NOT_FOUND));
+
+		// 예약 승인
+		ReservationStatusType status = reservation.getReservationStatus().getStatus();
+		switch (status) {
+			case PENDING:
+				reservation.getReservationStatus().approve(admin);
+				break;
+			case APPROVED:
+				throw new ReservationException(ReservationErrorCode.RESERVATION_ALREADY_APPROVED);
+			case REJECTED:
+				throw new ReservationException(ReservationErrorCode.RESERVATION_ALREADY_REJECTED);
+			default:
+				throw new ReservationException(ReservationErrorCode.RESERVATION_ALREADY_CANCELED);
+		}
+	}
+}

--- a/src/main/java/com/groomiz/billage/reservation/service/AdminReservationService.java
+++ b/src/main/java/com/groomiz/billage/reservation/service/AdminReservationService.java
@@ -49,4 +49,27 @@ public class AdminReservationService {
 				throw new ReservationException(ReservationErrorCode.RESERVATION_ALREADY_CANCELED);
 		}
 	}
+
+	public void rejectReservation(Long reservationId, String rejectionReason, String studentNumber) {
+
+		Member admin = memberRepository.findByStudentNumber(studentNumber)
+			.orElseThrow(() -> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND));
+
+		Reservation reservation = reservationRepository.findById(reservationId)
+			.orElseThrow(() -> new ReservationException(ReservationErrorCode.RESERVATION_NOT_FOUND));
+
+		// 예약 거절
+		ReservationStatusType status = reservation.getReservationStatus().getStatus();
+		switch (status) {
+			case PENDING:
+				reservation.getReservationStatus().reject(admin, rejectionReason);
+				break;
+			case APPROVED:
+				throw new ReservationException(ReservationErrorCode.RESERVATION_ALREADY_APPROVED);
+			case REJECTED:
+				throw new ReservationException(ReservationErrorCode.RESERVATION_ALREADY_REJECTED);
+			default:
+				throw new ReservationException(ReservationErrorCode.RESERVATION_ALREADY_CANCELED);
+		}
+	}
 }

--- a/src/main/java/com/groomiz/billage/reservation/service/ReservationService.java
+++ b/src/main/java/com/groomiz/billage/reservation/service/ReservationService.java
@@ -120,11 +120,11 @@ public class ReservationService {
 			throw new ReservationException(ReservationErrorCode.RESERVATION_ALREADY_REJECTED);
 		}
 
-		if (reservation.getReservationStatus().isStudentCanceled()) {
+		if (reservation.getReservationStatus().isCanceledByStudent()) {
 			throw new ReservationException(ReservationErrorCode.RESERVATION_ALREADY_DELETED);
 		}
 
-		if (reservation.getReservationStatus().isAdminCanceled()) {
+		if (reservation.getReservationStatus().isCanceledByAdmin()) {
 			throw new ReservationException(ReservationErrorCode.RESERVATION_ALREADY_REJECTED);
 		}
 

--- a/src/main/java/com/groomiz/billage/reservation/service/ReservationService.java
+++ b/src/main/java/com/groomiz/billage/reservation/service/ReservationService.java
@@ -138,6 +138,7 @@ public class ReservationService {
 		reservation.getReservationStatus().updateStatus(ReservationStatusType.STUDENT_CANCELED);
 	}
 
+	@Transactional(readOnly = true)
 	public ReservationStatusListResponse getAllReservationStatus(String studentNumber) {
 
 		Member member = memberRepository.findByStudentNumber(studentNumber)

--- a/src/main/java/com/groomiz/billage/reservation/service/ReservationService.java
+++ b/src/main/java/com/groomiz/billage/reservation/service/ReservationService.java
@@ -1,7 +1,8 @@
 package com.groomiz.billage.reservation.service;
 
+import static com.groomiz.billage.common.util.DateUtills.*;
+
 import java.time.LocalDate;
-import java.time.LocalTime;
 import java.util.List;
 
 import org.springframework.stereotype.Service;
@@ -141,10 +142,6 @@ public class ReservationService {
 		}
 
 		reservation.getReservationStatus().updateStatus(ReservationStatusType.STUDENT_CANCELED);
-	}
-
-	public boolean isTimeOverlapping(LocalTime startTime1, LocalTime endTime1, LocalTime startTime2, LocalTime endTime2) {
-		return startTime1.isBefore(endTime2) && startTime2.isBefore(endTime1);
 	}
 
 	public ReservationStatusListResponse getAllReservationStatus(String studentNumber) {

--- a/src/main/java/com/groomiz/billage/reservation/service/ReservationService.java
+++ b/src/main/java/com/groomiz/billage/reservation/service/ReservationService.java
@@ -115,17 +115,11 @@ public class ReservationService {
 
 		if (reservation.getReservationStatus().isApproved()) {
 			throw new ReservationException(ReservationErrorCode.RESERVATION_ALREADY_APPROVED);
-		}
-
-		if (reservation.getReservationStatus().isRejected()) {
+		} else if (reservation.getReservationStatus().isRejected()) {
 			throw new ReservationException(ReservationErrorCode.RESERVATION_ALREADY_REJECTED);
-		}
-
-		if (reservation.getReservationStatus().isCanceledByStudent()) {
+		} else if (reservation.getReservationStatus().isCanceledByStudent()) {
 			throw new ReservationException(ReservationErrorCode.RESERVATION_ALREADY_DELETED);
-		}
-
-		if (reservation.getReservationStatus().isCanceledByAdmin()) {
+		} else if (reservation.getReservationStatus().isCanceledByAdmin()) {
 			throw new ReservationException(ReservationErrorCode.RESERVATION_ALREADY_REJECTED);
 		}
 

--- a/src/main/java/com/groomiz/billage/reservation/service/ReservationService.java
+++ b/src/main/java/com/groomiz/billage/reservation/service/ReservationService.java
@@ -107,7 +107,7 @@ public class ReservationService {
 	}
 
 	// 학생 예약 취소
-	public void cancleReservation(Long id, String studentNumber) {
+	public void cancelReservation(Long id, String studentNumber) {
 
 		Reservation reservation = reservationRepository.findById(id)
 			.orElseThrow(() -> new ReservationException(ReservationErrorCode.RESERVATION_NOT_FOUND));
@@ -120,11 +120,11 @@ public class ReservationService {
 			throw new ReservationException(ReservationErrorCode.RESERVATION_ALREADY_REJECTED);
 		}
 
-		if (reservation.getReservationStatus().isStudentCancled()) {
+		if (reservation.getReservationStatus().isStudentCanceled()) {
 			throw new ReservationException(ReservationErrorCode.RESERVATION_ALREADY_DELETED);
 		}
 
-		if (reservation.getReservationStatus().isAdminCancled()) {
+		if (reservation.getReservationStatus().isAdminCanceled()) {
 			throw new ReservationException(ReservationErrorCode.RESERVATION_ALREADY_REJECTED);
 		}
 
@@ -140,7 +140,7 @@ public class ReservationService {
 			throw new ReservationException(ReservationErrorCode.USER_RESERVATION_MISMATCH);
 		}
 
-		reservation.getReservationStatus().updateStatus(ReservationStatusType.STUDENT_CANCLED);
+		reservation.getReservationStatus().updateStatus(ReservationStatusType.STUDENT_CANCELED);
 	}
 
 	public boolean isTimeOverlapping(LocalTime startTime1, LocalTime endTime1, LocalTime startTime2, LocalTime endTime2) {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,6 +2,11 @@ spring:
   profiles:
     active: dev
 
+  data:
+    redis:
+      cache:
+        fcm-ttl: 2592000000 # 30일
+
 server:
   port: 8080
 
@@ -14,4 +19,9 @@ springdoc:
     disable-swagger-default-url: true
     display-request-duration: true
     operations-sorter: alpha
+
+fcm:
+  key:
+    path: /firebase/billage-3a51a-firebase-adminsdk-b2r5m-29b2d39c20.json
+    scope: https://www.googleapis.com/auth/cloud-platform
 

--- a/src/test/java/com/groomiz/billage/reservation/service/AdminReservationServiceTest.java
+++ b/src/test/java/com/groomiz/billage/reservation/service/AdminReservationServiceTest.java
@@ -145,7 +145,7 @@ class AdminReservationServiceTest {
 
 	private Member register(String username, Role role, String studentNumber) {
 		RegisterRequest registerRequest = new RegisterRequest(username, studentNumber, "password1234!", "010-1234-5678",
-			"정보통신대학", "컴퓨터공학과", "asdf1234@gmail.com");
+			"정보통신대학", "컴퓨터공학과", true, "asdf1234@gmail.com");
 
 		memberService.register(registerRequest);
 		return memberRepository.findByStudentNumber(studentNumber).get();

--- a/src/test/java/com/groomiz/billage/reservation/service/AdminReservationServiceTest.java
+++ b/src/test/java/com/groomiz/billage/reservation/service/AdminReservationServiceTest.java
@@ -1,0 +1,173 @@
+package com.groomiz.billage.reservation.service;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.Rollback;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.groomiz.billage.auth.dto.RegisterRequest;
+import com.groomiz.billage.building.entity.Building;
+import com.groomiz.billage.building.entity.BuildingAdmin;
+import com.groomiz.billage.building.repository.BuildingAdminRepository;
+import com.groomiz.billage.building.repository.BuildingRepository;
+import com.groomiz.billage.classroom.entity.Classroom;
+import com.groomiz.billage.classroom.repository.ClassroomRepository;
+import com.groomiz.billage.member.entity.Member;
+import com.groomiz.billage.member.entity.Role;
+import com.groomiz.billage.member.repository.MemberRepository;
+import com.groomiz.billage.member.service.MemberService;
+import com.groomiz.billage.reservation.dto.request.ClassroomReservationRequest;
+import com.groomiz.billage.reservation.dto.response.AdminReservationStatusListResponse;
+import com.groomiz.billage.reservation.entity.ReservationPurpose;
+import com.groomiz.billage.reservation.entity.ReservationStatusType;
+import com.groomiz.billage.reservation.repository.ReservationRepository;
+
+import lombok.extern.slf4j.Slf4j;
+
+@SpringBootTest
+@Transactional
+@Slf4j
+class AdminReservationServiceTest {
+
+	@Autowired
+	AdminReservationService adminReservationService;
+
+	@Autowired
+	MemberRepository memberRepository;
+	@Autowired
+	MemberService memberService;
+
+	@Autowired
+	BuildingRepository buildingRepository;
+
+	@Autowired
+	ClassroomRepository classroomRepository;
+
+	@Autowired
+	ReservationService reservationService;
+	@Autowired
+	ReservationRepository reservationRepository;
+	@Autowired
+	private BuildingAdminRepository buildingAdminRepository;
+
+	@BeforeEach
+	public void setUp() {
+		register("admin", Role.ADMIN, "1");
+		register("student", Role.STUDENT, "2");
+
+		Member admin = memberRepository.findByStudentNumber("1").get();
+		Member student = memberRepository.findByStudentNumber("2").get();
+
+
+		Building building = saveBuilding("미래관");
+		Building building2 = saveBuilding("상상관");
+		Classroom classroom = saveClassroom(building);
+		Classroom classroom2 = saveClassroom(building2);
+
+		LocalDate applyDate = LocalDate.now();
+		LocalDate applyDate2 = LocalDate.now().plusDays(3);
+		LocalTime startTime = LocalTime.of(13, 0);
+		LocalTime endTime = LocalTime.of(14, 0);
+		LocalTime startTime2 = LocalTime.of(15, 0);
+		LocalTime endTime2 = LocalTime.of(16, 0);
+		LocalTime startTime3 = LocalTime.of(17, 0);
+		LocalTime endTime3 = LocalTime.of(20, 0);
+		LocalTime startTime4 = LocalTime.of(13, 0);
+		LocalTime endTime4 = LocalTime.of(16, 0);
+
+		Long rid = reserveClassroom(classroom, student, applyDate, startTime, endTime);
+		Long rid2 = reserveClassroom(classroom, student, applyDate, startTime2, endTime2);
+		Long rid3 = reserveClassroom(classroom, student, applyDate2, startTime3, endTime3);
+		Long rid4 = reserveClassroom(classroom2, admin, applyDate, startTime4, endTime4);
+		Long rid5 = reserveClassroom(classroom2, admin, applyDate2, startTime2, endTime2);
+		Long rid6 = reserveClassroom(classroom2, student, applyDate2, startTime3, endTime3);
+
+		// 대기 2, 승인 1, 거절 1, 관리자 취소 1, 학생 취소 1
+		reservationRepository.findById(rid).get().getReservationStatus().approve(admin);
+		reservationRepository.findById(rid2).get().getReservationStatus().reject(admin, "null");
+		reservationRepository.findById(rid5).get().getReservationStatus().cancelByAdmin(admin);
+		reservationRepository.findById(rid6).get().getReservationStatus().approve(admin);
+		reservationRepository.findById(rid6).get().getReservationStatus().cancelByStudent();
+
+		BuildingAdmin buildingAdmin = new BuildingAdmin(admin, building);
+		BuildingAdmin buildingAdmin2 = new BuildingAdmin(admin, building2);
+		buildingAdminRepository.save(buildingAdmin);
+		buildingAdminRepository.save(buildingAdmin2);
+	}
+
+	@Test
+	@Rollback(value = false)
+	public void 관리자_대기_예약_조회_성공() throws Exception{
+	    //given
+		String adminStudentNumber = "1";
+
+	    //when
+		AdminReservationStatusListResponse pending = adminReservationService.getReservationByStatus(
+			ReservationStatusType.PENDING, adminStudentNumber);
+		AdminReservationStatusListResponse approved = adminReservationService.getReservationByStatus(
+			ReservationStatusType.APPROVED, adminStudentNumber);
+		AdminReservationStatusListResponse rejectedAndCanceled = adminReservationService.getReservationByStatus(
+			ReservationStatusType.REJECTED, adminStudentNumber);
+
+	    //then
+		Assertions.assertAll(
+			() -> {
+				assertThat(pending.getReservations().size()).isEqualTo(2);
+				assertThat(approved.getReservations().size()).isEqualTo(1);
+				assertThat(rejectedAndCanceled.getReservations().size()).isEqualTo(3);
+			}
+		);
+	}
+
+	private Long reserveClassroom(Classroom classroom, Member student, LocalDate applyDate, LocalTime startTime, LocalTime endTime) {
+		String phoneNumber = "010-1234-5678";
+
+		ClassroomReservationRequest request = ClassroomReservationRequest.builder()
+			.classroomId(classroom.getId())
+			.phoneNumber(phoneNumber)
+			.applyDate(applyDate)
+			.headcount(30)
+			.startTime(startTime)
+			.endTime(endTime)
+			.purpose(ReservationPurpose.CLUB_EVENT)
+			.build();
+
+		return reservationService.reserveClassroom(request, student.getStudentNumber());
+	}
+
+	private Member register(String username, Role role, String studentNumber) {
+		RegisterRequest registerRequest = new RegisterRequest(username, studentNumber, "password1234!", "010-1234-5678",
+			"정보통신대학", "컴퓨터공학과", "asdf1234@gmail.com");
+
+		memberService.register(registerRequest);
+		return memberRepository.findByStudentNumber(studentNumber).get();
+	}
+
+	private Building saveBuilding(String name) {
+		Building building = Building.builder()
+			.name(name)
+			.number("60")
+			.build();
+
+		return buildingRepository.save(building);
+	}
+
+	private Classroom saveClassroom(Building building) {
+		Classroom classroom = Classroom.builder()
+			.number("101")
+			.floor(1L)
+			.capacity(30)
+			.building(building)
+			.build();
+
+		return classroomRepository.save(classroom);
+	}
+}

--- a/src/test/java/com/groomiz/billage/reservation/service/ReservationServiceTest.java
+++ b/src/test/java/com/groomiz/billage/reservation/service/ReservationServiceTest.java
@@ -117,13 +117,13 @@ class ReservationServiceTest {
 		Long reservationId = reserveClassroom(classroom, student, applyDate, startTime, endTime);
 
 		//when
-		reservationService.cancleReservation(reservationId, student.getStudentNumber());
+		reservationService.cancelReservation(reservationId, student.getStudentNumber());
 
 		//then
 		Reservation reservation = reservationRepository.findById(reservationId)
 			.orElseThrow(() -> new ReservationException(ReservationErrorCode.RESERVATION_NOT_FOUND));
 
-		assertThat(reservation.getReservationStatus().isStudentCancled()).isTrue();
+		assertThat(reservation.getReservationStatus().isCanceledByStudent()).isTrue();
 	}
 
 
@@ -146,7 +146,7 @@ class ReservationServiceTest {
 		reservation.getReservationStatus().updateStatus(ReservationStatusType.REJECTED);
 
 		//then
-		assertThatThrownBy(() -> reservationService.cancleReservation(reservationId, student.getStudentNumber()))
+		assertThatThrownBy(() -> reservationService.cancelReservation(reservationId, student.getStudentNumber()))
 			.isInstanceOf(ReservationException.class);
 	}
 


### PR DESCRIPTION
## ✅ 풀\_리퀘스트 체크리스트

<!--
하나씩 확인 후 체크박스에 표시해주세요.
-->

- [x] PR 제목: [Feature/Fix/Refactor...] 작업 내용 한 줄 요약 (브랜치 이름) #이슈번호
- [x] commit message 가 적절한지 확인해주세요.
- [x] 적절한 branch 로 요청했는지 확인해주세요.
- [x] Assignees, Label 을 붙여주세요.
- [x] 주의 사항과 관련해 꼭 확인해야 할 사람이 있다면 Reviewer 로 등록해주세요.
- [x] PR이 승인된 경우 해당 브랜치는 삭제해 주세요!

<br/>

## 🔄 변경 사항

관리자 예약 관련 기능 모두 추가했습니다. 

1. 관리자 예약 승인 기능 추가했습니다.
2. 관리자 예약 거절 기능 추가했습니다. (커밋메시지 예약 취소라고 잘못 남겼어요.. 거절입니다)
3. 관리자 예약 승인/거절 시 FCM 사용해서 푸시 알림 보내는 기능 추가했습니다. 
  - FCM 관련 기능 서비스로 생성했습니다.
  - fcm 토큰 redis에 저장하도록 구현했습니다. (ex. key: FCM_200000)
  - fcm 토큰 저장하는 api 추가하였습니다.
  - 로그아웃 시 fcm 토큰 redis에서 삭제되도록 하였습니다.
4. 관리자의 강의실 예약(일반/기간/반복) 기능 추가했습니다.
  - ReservationGroup 테이블 추가했습니다.
5. 존재하지 않는 ENUM 값 요청 시 커스텀 에러 반환하게 수정했습니다.
6. 관리자 예약 상세 정보 조회 기능 추가했습니다.
7. 관리자 학생 예약 강제 취소 기능 추가했습니다.
8. 관리자 일반/기간/반복 예약 취소 기능 추가했습니다.
  - uri에 일괄 삭제 여부를 구분하는 쿼리스트링 추가했습니다.
9. 관리자 예약 상태별 조회 기능 추가했습니다.
10. 관리자 강의실 상세 조회 기능 추가했습니다.
11. 관리자 강의실 상세 정보 조회 기능 추가했습니다.
  - 기존 query parameter로 받던 강의실 id를 path parameter로 받도록 수정했습니다.
  - 대기/승인 예약만 반환하게 구현했습니다.
12. 학생 강의실 상세 정보 조회 기능 추가했습니다. (관리자 강의실 응답이 학생 강의실 응답으로 잘못 설정되어 그걸 개발하고 다하고 알아서... 이것도 구현되어 있습니다..🥹)
  - 기존 query parameter로 받던 강의실 id를 path parameter로 받도록 수정했습니다.
  - 대기/승인 예약만 반환하게 구현했습니다.
13. 관리자 강의실 필터링 조회 기능 추가했습니다.
  - 요청의 건물, 층 array가 null이나 빈 array일 경우 모든 건물과 모든 층에 대해서 조회하도록 구현했습니다.

<br/>

## 📎 변경한 이유

-  ReservationGroup 테이블은 추후 일괄 삭제를 위해 기간/반복 예약일 시에 저장하기 위해 추가하였습니다.
- 알맞지 않은 enum 값으로 요청 왔을 경우 커스텀 에러가 반환되지 않아서 커스텀 에러가 반환될 수 있도록 수정하였습니다.
- 관리자가 기간/반복 예약 취소할 때 일괄 삭제할지 해당 예약만 취소할지 구분하기 위해 일괄 삭제 여부를 구분하는 쿼리스트링 추가했습니다.
<br/>

<!-- 관련되어있는 Issue Number 를 작성하세요! 해당 이슈를 이곳에 적으면 pr merge 이후 해당 이슈는 자동으로 close 됩니다. -->


## 👨🏻‍💻 테스트 체크리스트

- 예약 상태별로 조회하는 테스트 진행했습니다.

<br/>

## 📌 변경 및 주의 사항

<!--
변경사항 및 주의 사항이 있다면 적어주세요.
주의 사항과 관련해 꼭 확인해야 할 사람이 있다면 리뷰어로 등록해주세요. (다른 사람이 작성한 코드 수정 등)
코드 리뷰 시 더 꼼꼼하게 확인 받고 싶은 부분이 있다면 적어주세요.
-->

FCM 관련 secret 파일들 notion 서버 파트 secret 페이지에 업로드 해놔서 /resources/firebase 위치에 billage-3a51a-firebase-adminsdk-b2r5m-29b2d39c20.json 파일 넣어주시면 됩니다! 
+) 푸시 알림 기능은 백엔드에서는 응답 잘되는 거 확인했는데 푸시 알림이 뜨는지는 테스트 불가능해서 프론트랑 추후에 확인해봐야할 거 같습니다.

<img width="330" alt="image" src="https://github.com/user-attachments/assets/cb6a094f-241b-4d82-834d-6459d010c15d">

그리고 정보 같은 것들 조회해올 때 강의실, 건물, 예약, 예약 상태, 요청 멤버 등 많은 테이블을 조회해와야해서 일단 join해서 조회해오거나 나눠서 join하는 방식으로 구현했는데 여러 테이블 join하다보니까 컬럼수가 너무 많아져서 리팩토링 해야할 거 같아서 그 부분 추후에 수정하겠습니다.

예약 조회 같은 경우 전체 기간의 예약을 조회해오는 건 비효율적인 거 같습니다. (관리자의 경우 예약 건수가 너무 많아요.) 다른 서비스들도 사용자에게 기간(ex. 최대 한달)을 선택할 수 있게 해서 해당 기간 동안의 정보만 조회해오는 방식을 사용하는 거 같은데 우리도 그 방식 혹은 페이징 방식을 사용하는 것으로 추후 리팩토링 하는 거 어떨까요


<br/>